### PR TITLE
[feature/backend-22/hobbyboard/get-hobby-detail] 취미 게시판 취미 상세 조회 Rest api 구현

### DIFF
--- a/http/hobbyTest.http
+++ b/http/hobbyTest.http
@@ -1,3 +1,5 @@
 ###취미 게시판 전체 보기
 GET http://localhost:8081/hobby-board
 
+###취미 게시판 상세 보기
+GET http://localhost:8081/hobby-detail/1

--- a/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
+++ b/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
@@ -42,4 +42,18 @@ public class HobbyController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));
     }
 
+    //취미 상세 조회
+    @GetMapping("/hobby-detail/{hobbyNumber}")
+    public ResponseEntity<ResponseMessage> findHobbyDetail(@PathVariable("hobbyNumber")int hobbyNumber){
+
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+
+        HobbyDTO hobbyDTO = hobbyService.findById(hobbyNumber);
+
+        Map<String, Object> responseMap = new HashMap<String, Object>();
+        responseMap.put("hobby", hobbyDTO);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));
+    }
+
 }

--- a/src/main/java/com/senials/hobbyboard/service/HobbyService.java
+++ b/src/main/java/com/senials/hobbyboard/service/HobbyService.java
@@ -18,13 +18,21 @@ public class HobbyService {
         this.hobbyRepository=hobbyRepository;
         this.hobbyMapper=hobbyMapper;
     }
-
+    //전체 hobby 불러오기
     public List<HobbyDTO>findAll(){
         List<Hobby> hobbyList=hobbyRepository.findAll();
 
         List<HobbyDTO> hobbyDTOList=hobbyList.stream().map(hobby -> hobbyMapper.toHobbyDTO(hobby)).toList();
 
         return hobbyDTOList;
+    }
+
+    //특정 hobby hobbyNumber로 불러오기
+    public HobbyDTO findById(int hobbyNumber){
+        Hobby hobby=hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미가 존재하지 않습니다: " + hobbyNumber));
+        HobbyDTO hobbyDTO=hobbyMapper.toHobbyDTO(hobby);
+
+        return hobbyDTO;
     }
 
 }


### PR DESCRIPTION
## 이슈
- #22 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/2010d366-93e3-4c16-bc85-659fe2b94b2f)


## 📝작업 내용
- 취미 게시판 취미 상세 조회 Rest api 구현
  - service finById()로 특정 hobby hobbyNumber로 불러오게 구성
  - controller findHobbyDetail()에 service 연결 취미 상세 조회

## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/bab3ca9b-0871-4a74-bbda-b738672b7fb3)


## 🚨수정 필요 내용
- 
