### PR TITLE
[feature/backend-23/hobbyboard/get-category-hobby] 취미 게시판 카테고리 기준 취미조회 Rest api 기능 구현 

### DIFF
--- a/http/hobbyTest.http
+++ b/http/hobbyTest.http
@@ -3,3 +3,6 @@ GET http://localhost:8081/hobby-board
 
 ###취미 게시판 상세 보기
 GET http://localhost:8081/hobby-detail/1
+
+###취미 게시판 카테고리별 전체보기
+GET http://localhost:8081/hobby-board/3

--- a/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
+++ b/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
@@ -56,4 +56,18 @@ public class HobbyController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));
     }
 
+    //취미 카테고리별 취미 목록 조회
+    @GetMapping("/hobby-board/{categoryNumber}")
+    public ResponseEntity<ResponseMessage> findHobbyByCategory(@PathVariable("categoryNumber")int categoryNumber){
+
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+
+        List<HobbyDTO> hobbyDTOList = hobbyService.findByCategory(categoryNumber);
+
+        Map<String, Object> responseMap = new HashMap<String, Object>();
+        responseMap.put("hobby", hobbyDTOList);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));
+    }
+
 }

--- a/src/main/java/com/senials/hobbyboard/repository/HobbyRepository.java
+++ b/src/main/java/com/senials/hobbyboard/repository/HobbyRepository.java
@@ -4,6 +4,9 @@ import com.senials.hobbyboard.entity.Hobby;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface HobbyRepository extends JpaRepository<Hobby, Integer> {
+    List<Hobby> findByCategoryNumber(int categoryNumber);
 }

--- a/src/main/java/com/senials/hobbyboard/service/HobbyService.java
+++ b/src/main/java/com/senials/hobbyboard/service/HobbyService.java
@@ -35,4 +35,12 @@ public class HobbyService {
         return hobbyDTO;
     }
 
+    public List<HobbyDTO>findByCategory(int categoryNumber){
+        List<Hobby> hobbyList=hobbyRepository.findByCategoryNumber(categoryNumber);
+
+        List<HobbyDTO> hobbyDTOList=hobbyList.stream().map(hobby -> hobbyMapper.toHobbyDTO(hobby)).toList();
+
+        return hobbyDTOList;
+    }
+
 }

--- a/src/main/java/com/senials/hobbyboard/service/HobbyService.java
+++ b/src/main/java/com/senials/hobbyboard/service/HobbyService.java
@@ -35,6 +35,7 @@ public class HobbyService {
         return hobbyDTO;
     }
 
+    //특정 hobby들 categoryNumber로 불러오기
     public List<HobbyDTO>findByCategory(int categoryNumber){
         List<Hobby> hobbyList=hobbyRepository.findByCategoryNumber(categoryNumber);
 


### PR DESCRIPTION
## 이슈
- #23 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/8b0ddfdc-4a3a-4ad8-a88e-44cce89b90a3)


## 📝작업 내용
- 취미 게시판 카테고리 기준 취미조회 Rest api 기능 구현 
  - repository findByCategoryNumber() 쿼리 메소드 추가
  - service findByCategory() 추가, 특정 hobby들 categoryNumber로 불러오기
  - controller findHobbyByCategory()추가 및 연결, rest api 생성


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/6248750a-6692-4849-92f3-93f7cd1c2e2c)


## 🚨수정 필요 내용
- 
