### PR TITLE
[feature/backend-5/partyboards/delete-partyboard] 모임 글 삭제 REST API 구현

### DIFF
--- a/http/partyboard.http
+++ b/http/partyboard.http
@@ -7,3 +7,6 @@ Content-Type: application/json;charset=utf-8
 {
 
 }
+
+### 모임 글 삭제
+DELETE http://localhost:8080/partyboards/18

--- a/src/main/java/com/senials/partyboard/controller/PartyBoardController.java
+++ b/src/main/java/com/senials/partyboard/controller/PartyBoardController.java
@@ -76,4 +76,19 @@ public class PartyBoardController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "글 수정 성공", null));
     }
 
+
+    /* 모임 글 삭제 */
+    @DeleteMapping("/partyboards/{partyBoardNumber}")
+    public ResponseEntity<ResponseMessage> removePartyBoard(
+            @PathVariable int partyBoardNumber
+    ) {
+
+        partyBoardService.removePartyBoard(partyBoardNumber);
+
+        // ResponseHeader 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "글 삭제 성공", null));
+    }
+
 }

--- a/src/main/java/com/senials/partyboard/service/PartyBoardService.java
+++ b/src/main/java/com/senials/partyboard/service/PartyBoardService.java
@@ -162,4 +162,11 @@ public class PartyBoardService {
         }
     }
 
+    /* 모임 글 삭제 */
+    @Transactional
+    public void removePartyBoard(int partyBoardNumber) {
+
+        partyBoardRepository.deleteById(partyBoardNumber);
+    }
+
 }


### PR DESCRIPTION
## 이슈
- Resolve #5


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/baad2abe-5e8e-4788-be78-868427bcf1ba)


## 📝작업 내용
- 모임 게시글 삭제 REST API를 구현함
  - 모임에 속한 이미지도 함께 삭제 확인


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
- ### 18번 게시글 삭제전
![image](https://github.com/user-attachments/assets/2dbe9b81-d261-48e6-a33a-cd45311222b5)

- ### 삭제 후
![image](https://github.com/user-attachments/assets/9ae4c212-84d2-4371-b149-e1b6c4e0d2b1)

![image](https://github.com/user-attachments/assets/0909e54a-bce7-48c0-a0fa-b9a6c819b9bf)

