### PR TITLE
[feature/backend-24/hobbyreview/get-hobbyreview-all] 취미에 해당하는 후기 전체 조회 Rest api 기능 구현

### DIFF
--- a/http/hobbyTest.http
+++ b/http/hobbyTest.http
@@ -1,7 +1,7 @@
 ###취미 게시판 전체 보기
 GET http://localhost:8081/hobby-board
 
-###취미 게시판 상세 보기
+###취미 게시판 상세 보기, 관련된 후기 가져오기
 GET http://localhost:8081/hobby-detail/1
 
 ###취미 게시판 카테고리별 전체보기

--- a/src/main/java/com/senials/common/mapper/HobbyReviewMapper.java
+++ b/src/main/java/com/senials/common/mapper/HobbyReviewMapper.java
@@ -1,0 +1,14 @@
+package com.senials.common.mapper;
+
+import com.senials.hobbyreview.dto.HobbyReviewDTO;
+import com.senials.hobbyreview.entity.HobbyReview;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface HobbyReviewMapper {
+
+    HobbyReviewDTO toHobbyReviewDTO(HobbyReview hobbyReview);
+
+    HobbyReview toHobbyReviewEntity(HobbyReviewDTO hobbyReviewDTO);
+
+}

--- a/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
+++ b/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
@@ -4,6 +4,7 @@ import com.senials.common.ResponseMessage;
 import com.senials.config.HttpHeadersFactory;
 import com.senials.hobbyboard.dto.HobbyDTO;
 import com.senials.hobbyboard.service.HobbyService;
+import com.senials.hobbyreview.dto.HobbyReviewDTO;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,15 +43,17 @@ public class HobbyController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));
     }
 
-    //취미 상세 조회
+    //취미 상세 조회, 해당 취미후기 리스트 조회
     @GetMapping("/hobby-detail/{hobbyNumber}")
     public ResponseEntity<ResponseMessage> findHobbyDetail(@PathVariable("hobbyNumber")int hobbyNumber){
 
         HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
 
         HobbyDTO hobbyDTO = hobbyService.findById(hobbyNumber);
+        List<HobbyReviewDTO> hobbyReviewDTOList=hobbyService.getReviewsListByHobbyNumber(hobbyNumber);
 
         Map<String, Object> responseMap = new HashMap<String, Object>();
+        responseMap.put("hobbyReview",hobbyReviewDTOList);
         responseMap.put("hobby", hobbyDTO);
 
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));

--- a/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
+++ b/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
@@ -5,6 +5,7 @@ import com.senials.config.HttpHeadersFactory;
 import com.senials.hobbyboard.dto.HobbyDTO;
 import com.senials.hobbyboard.service.HobbyService;
 import com.senials.hobbyreview.dto.HobbyReviewDTO;
+import com.senials.hobbyreview.service.HobbyReviewService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,9 +24,12 @@ public class HobbyController {
     private HobbyService hobbyService;
     private final HttpHeadersFactory httpHeadersFactory;
 
-    public HobbyController(HobbyService hobbyService, HttpHeadersFactory httpHeadersFactory){
+    private HobbyReviewService hobbyReviewService;
+
+    public HobbyController(HobbyService hobbyService,HobbyReviewService hobbyReviewService, HttpHeadersFactory httpHeadersFactory){
 
         this.hobbyService=hobbyService;
+        this.hobbyReviewService=hobbyReviewService;
         this.httpHeadersFactory = httpHeadersFactory;
     }
 
@@ -50,7 +54,7 @@ public class HobbyController {
         HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
 
         HobbyDTO hobbyDTO = hobbyService.findById(hobbyNumber);
-        List<HobbyReviewDTO> hobbyReviewDTOList=hobbyService.getReviewsListByHobbyNumber(hobbyNumber);
+        List<HobbyReviewDTO> hobbyReviewDTOList=hobbyReviewService.getReviewsListByHobbyNumber(hobbyNumber);
 
         Map<String, Object> responseMap = new HashMap<String, Object>();
         responseMap.put("hobbyReview",hobbyReviewDTOList);

--- a/src/main/java/com/senials/hobbyboard/service/HobbyService.java
+++ b/src/main/java/com/senials/hobbyboard/service/HobbyService.java
@@ -1,9 +1,13 @@
 package com.senials.hobbyboard.service;
 
 import com.senials.common.mapper.HobbyMapper;
+import com.senials.common.mapper.HobbyReviewMapper;
 import com.senials.hobbyboard.dto.HobbyDTO;
 import com.senials.hobbyboard.entity.Hobby;
 import com.senials.hobbyboard.repository.HobbyRepository;
+import com.senials.hobbyreview.dto.HobbyReviewDTO;
+import com.senials.hobbyreview.entity.HobbyReview;
+import com.senials.hobbyreview.repository.HobbyReviewRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,10 +17,14 @@ public class HobbyService {
 
     private final HobbyMapper hobbyMapper;
     private final HobbyRepository hobbyRepository;
+    private final HobbyReviewMapper hobbyReviewMapper;
+    private final HobbyReviewRepository hobbyReviewRepository;
 
-    public HobbyService(HobbyRepository hobbyRepository, HobbyMapper hobbyMapper){
+    public HobbyService(HobbyRepository hobbyRepository, HobbyMapper hobbyMapper, HobbyReviewRepository hobbyReviewRepository, HobbyReviewMapper hobbyReviewMapper){
         this.hobbyRepository=hobbyRepository;
         this.hobbyMapper=hobbyMapper;
+        this.hobbyReviewRepository=hobbyReviewRepository;
+        this.hobbyReviewMapper=hobbyReviewMapper;
     }
     //전체 hobby 불러오기
     public List<HobbyDTO>findAll(){
@@ -42,6 +50,21 @@ public class HobbyService {
         List<HobbyDTO> hobbyDTOList=hobbyList.stream().map(hobby -> hobbyMapper.toHobbyDTO(hobby)).toList();
 
         return hobbyDTOList;
+    }
+
+    //취미 번호가 같은 취미리뷰 리스트 불러오기
+    public List<HobbyReviewDTO> getReviewsListByHobbyNumber(int hobbyNumber) {
+        Hobby hobby = hobbyRepository.findById(hobbyNumber)
+                .orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
+        List<HobbyReview> hobbyReviewList=hobbyReviewRepository.findByHobby(hobby);
+        List<HobbyReviewDTO> hobbyReviewDTOList=hobbyReviewList.stream().map(hobbyReview -> {
+            HobbyReviewDTO dto=hobbyReviewMapper.toHobbyReviewDTO(hobbyReview);
+            dto.setHobbyNumber(hobbyReview.getHobby().getHobbyNumber());
+            dto.setUserNumber(hobbyReview.getUser().getUserNumber());
+            dto.setUserName(hobbyReview.getUser().getUserName());
+            return dto;
+        }).toList();
+        return hobbyReviewDTOList;
     }
 
 }

--- a/src/main/java/com/senials/hobbyboard/service/HobbyService.java
+++ b/src/main/java/com/senials/hobbyboard/service/HobbyService.java
@@ -51,20 +51,4 @@ public class HobbyService {
 
         return hobbyDTOList;
     }
-
-    //취미 번호가 같은 취미리뷰 리스트 불러오기
-    public List<HobbyReviewDTO> getReviewsListByHobbyNumber(int hobbyNumber) {
-        Hobby hobby = hobbyRepository.findById(hobbyNumber)
-                .orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
-        List<HobbyReview> hobbyReviewList=hobbyReviewRepository.findByHobby(hobby);
-        List<HobbyReviewDTO> hobbyReviewDTOList=hobbyReviewList.stream().map(hobbyReview -> {
-            HobbyReviewDTO dto=hobbyReviewMapper.toHobbyReviewDTO(hobbyReview);
-            dto.setHobbyNumber(hobbyReview.getHobby().getHobbyNumber());
-            dto.setUserNumber(hobbyReview.getUser().getUserNumber());
-            dto.setUserName(hobbyReview.getUser().getUserName());
-            return dto;
-        }).toList();
-        return hobbyReviewDTOList;
-    }
-
 }

--- a/src/main/java/com/senials/hobbyreview/dto/HobbyReviewDTO.java
+++ b/src/main/java/com/senials/hobbyreview/dto/HobbyReviewDTO.java
@@ -1,0 +1,37 @@
+package com.senials.hobbyreview.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class HobbyReviewDTO {
+
+    private int hobbyReviewNumber; // 취미 후기 고유 번호
+    private int userNumber; // 사용자 번호
+    private String userName; // 사용자 이름
+    private int hobbyNumber; // 취미 고유 번호
+    private int hobbyReviewRate; // 후기 평점 (1~5)
+    private String hobbyReviewDetail; // 후기 상세 내용
+    private int hobbyReviewHealthStatus; // 건강 상태 (예: true = 예, false = 아니요)
+    private int hobbyReviewTendency; // 성향 (예: true = 외향적, false = 내향적)
+    private int hobbyReviewLevel; // 취미 난이도 (1-쉬움, 2-약간 쉬움, 3-평범, 4-약간 어려움, 5-어려움)
+    private String hobbyReviewWriteDate; // 후기 작성 날짜
+
+    public HobbyReviewDTO(int hobbyReviewNumber, int userNumber, String userName, int hobbyNumber, int hobbyReviewRate, String hobbyReviewDetail, int hobbyReviewHealthStatus, int hobbyReviewTendency, int hobbyReviewLevel, String hobbyReviewWriteDate) {
+        this.hobbyReviewNumber = hobbyReviewNumber;
+        this.userNumber = userNumber;
+        this.userName = userName;
+        this.hobbyNumber = hobbyNumber;
+        this.hobbyReviewRate = hobbyReviewRate;
+        this.hobbyReviewDetail = hobbyReviewDetail;
+        this.hobbyReviewHealthStatus = hobbyReviewHealthStatus;
+        this.hobbyReviewTendency = hobbyReviewTendency;
+        this.hobbyReviewLevel = hobbyReviewLevel;
+        this.hobbyReviewWriteDate = hobbyReviewWriteDate;
+    }
+}

--- a/src/main/java/com/senials/hobbyreview/repository/HobbyReviewRepository.java
+++ b/src/main/java/com/senials/hobbyreview/repository/HobbyReviewRepository.java
@@ -1,9 +1,13 @@
 package com.senials.hobbyreview.repository;
 
+import com.senials.hobbyboard.entity.Hobby;
 import com.senials.hobbyreview.entity.HobbyReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface HobbyReviewRepository extends JpaRepository<HobbyReview,Integer> {
+    List<HobbyReview> findByHobby(Hobby hobby);
 }

--- a/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
+++ b/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
@@ -1,0 +1,41 @@
+package com.senials.hobbyreview.service;
+import com.senials.common.mapper.HobbyReviewMapper;
+import com.senials.hobbyboard.entity.Hobby;
+import com.senials.hobbyboard.repository.HobbyRepository;
+import com.senials.hobbyreview.dto.HobbyReviewDTO;
+import com.senials.hobbyreview.entity.HobbyReview;
+import com.senials.hobbyreview.repository.HobbyReviewRepository;
+import com.senials.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class HobbyReviewService {
+    private final HobbyReviewMapper hobbyReviewMapper;
+    private final HobbyReviewRepository hobbyReviewRepository;
+    private final HobbyRepository hobbyRepository;
+    private final UserRepository userRepository;
+
+    HobbyReviewService(HobbyReviewRepository hobbyReviewRepository, HobbyReviewMapper hobbyReviewMapper, HobbyRepository hobbyRepository, UserRepository userRepository){
+        this.hobbyReviewMapper=hobbyReviewMapper;
+        this.hobbyReviewRepository=hobbyReviewRepository;
+        this.hobbyRepository=hobbyRepository;
+        this.userRepository=userRepository;
+    }
+
+    //취미 번호가 같은 취미리뷰 리스트 불러오기
+    public List<HobbyReviewDTO> getReviewsListByHobbyNumber(int hobbyNumber) {
+        Hobby hobby = hobbyRepository.findById(hobbyNumber)
+                .orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
+        List<HobbyReview> hobbyReviewList=hobbyReviewRepository.findByHobby(hobby);
+        List<HobbyReviewDTO> hobbyReviewDTOList=hobbyReviewList.stream().map(hobbyReview -> {
+            HobbyReviewDTO dto=hobbyReviewMapper.toHobbyReviewDTO(hobbyReview);
+            dto.setHobbyNumber(hobbyReview.getHobby().getHobbyNumber());
+            dto.setUserNumber(hobbyReview.getUser().getUserNumber());
+            dto.setUserName(hobbyReview.getUser().getUserName());
+            return dto;
+        }).toList();
+        return hobbyReviewDTOList;
+    }
+}


### PR DESCRIPTION
## 이슈
- #24 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/2defe454-00f9-48cc-855d-6105241be7a2)


## 📝작업 내용
- 취미에 해당하는 후기 전체 조회 Rest api 기능 구현
  - mapper HobbyReviewMapper 구성
  - dto HobbyReviewDTO 구성
  - repository HobbyReviewRepository 구성
  - repository HobbyReviewRepository findByHobby() 쿼리메소드 추가
  - service HobbyReviewService getReviewsListByHobbyNumber() 메소드 추가, 취미 번호가 같은 취미리뷰 리스트 불러오기
  - controller HobbyController  findHobbyDetail()에 메소드 추가, 취미 상세 조회시, 해당 취미의 리뷰들까지 같이 출력되게 수정


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)

![image](https://github.com/user-attachments/assets/d9e3f820-bc0c-4fd1-96e6-b4d730732aad)
![image](https://github.com/user-attachments/assets/673ff039-8ee4-4a67-95a8-0953efaf3243)
![image](https://github.com/user-attachments/assets/ed7b9cc5-f854-4f63-b5de-6298bf030061)



## 🚨수정 필요 내용
- 
