### PR TITLE
[feature/backend-25/hobbyreview/get-hobbyreview-detail] 취미 게시판 특정 취미 후기 정보 조회 Rest api 기능 구현

### DIFF
--- a/http/hobbyTest.http
+++ b/http/hobbyTest.http
@@ -6,3 +6,6 @@ GET http://localhost:8081/hobby-detail/1
 
 ###취미 게시판 카테고리별 전체보기
 GET http://localhost:8081/hobby-board/3
+
+###취미 게시판 후기 조회
+GET http://localhost:8081/1/hobby-review/13

--- a/src/main/java/com/senials/hobbyreview/controller/HobbyReviewController.java
+++ b/src/main/java/com/senials/hobbyreview/controller/HobbyReviewController.java
@@ -1,0 +1,44 @@
+package com.senials.hobbyreview.controller;
+
+import com.senials.common.ResponseMessage;
+import com.senials.config.HttpHeadersFactory;
+import com.senials.hobbyreview.dto.HobbyReviewDTO;
+import com.senials.hobbyreview.service.HobbyReviewService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+public class HobbyReviewController {
+
+    int userNumber=1;
+
+    private final HobbyReviewService hobbyReviewService;
+
+    private final HttpHeadersFactory httpHeadersFactory;
+
+    public HobbyReviewController(HobbyReviewService hobbyReviewService, HttpHeadersFactory httpHeadersFactory){
+        this.hobbyReviewService=hobbyReviewService;
+        this.httpHeadersFactory=httpHeadersFactory;
+    }
+
+    //취미 후기 조회
+    @GetMapping("{hobbyNumber}/hobby-review/{hobbyReviewNumber}")
+    public ResponseEntity<ResponseMessage> getHobbyReview(
+            @PathVariable("hobbyNumber") int hobbyNumber,
+            @PathVariable("hobbyReviewNumber") int hobbyReviewNumber) {
+
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+
+       HobbyReviewDTO hobbyReviewDTO= hobbyReviewService.getHobbyReview(hobbyNumber,userNumber,hobbyReviewNumber);
+
+        Map<String, Object> responseMap = new HashMap<String, Object>();
+        responseMap.put("hobbyReview",hobbyReviewDTO);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));
+    }
+
+}

--- a/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
+++ b/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
@@ -5,6 +5,7 @@ import com.senials.hobbyboard.repository.HobbyRepository;
 import com.senials.hobbyreview.dto.HobbyReviewDTO;
 import com.senials.hobbyreview.entity.HobbyReview;
 import com.senials.hobbyreview.repository.HobbyReviewRepository;
+import com.senials.user.entity.User;
 import com.senials.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
@@ -37,5 +38,25 @@ public class HobbyReviewService {
             return dto;
         }).toList();
         return hobbyReviewDTOList;
+    }
+
+    //취미번호, 유저번호, 리뷰번호를 통한 대조후 취미리뷰 조회
+    public HobbyReviewDTO getHobbyReview(int hobbyNumber, int userNumber, int hobbyReviewNumber){
+        User user= (User) userRepository.findById(userNumber).orElseThrow(() -> new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: " + userNumber));;
+        Hobby hobby=hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
+        HobbyReview hobbyReview = hobbyReviewRepository.findById(hobbyReviewNumber).orElseThrow(() -> new IllegalArgumentException("해당 리뷰 번호가 존재하지 않습니다: " + hobbyReviewNumber));
+        if(!hobbyReview.getUser().equals(user)){
+            throw new IllegalArgumentException("해당 유저의 리뷰가 아닙니다.");
+        }
+        if
+        (!hobbyReview.getHobby().equals(hobby)) {
+            throw new IllegalArgumentException("해당 취미의 리뷰가 아닙니다.");
+        }
+        HobbyReviewDTO hobbyReviewDTO=hobbyReviewMapper.toHobbyReviewDTO(hobbyReview);
+        hobbyReviewDTO.setHobbyNumber(hobby.getHobbyNumber());
+        hobbyReviewDTO.setUserNumber(user.getUserNumber());
+        hobbyReviewDTO.setUserName(hobbyReview.getUser().getUserName());
+
+        return hobbyReviewDTO;
     }
 }


### PR DESCRIPTION
## 이슈
- #25 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/b28402fe-0c83-43ce-b144-2a877d3ac143)


## 📝작업 내용
- 취미 게시판 특정 취미 후기 정보 조회 Rest api 기능 구현
  - service HobbyReviewService getHobbyReview() 메소드 추가, 취미번호, 유저번호, 리뷰번호를 통한 대조후 취미 후기 조회
  - controller HobbyReviewController getHobbyReview()메소드 추가 및 연결, 취미 후기 조회

## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/351d67de-4cc5-4b88-bd85-e3a849ec33b7)
![image](https://github.com/user-attachments/assets/a6b3996c-dc67-46b3-beef-afd0b94d3a9a)
![image](https://github.com/user-attachments/assets/e95ac5bd-c92b-4d45-b134-86b33aad9baf)




## 🚨수정 필요 내용
- 
