### PR TITLE
[feature/backend-3/partyboards/get-partyboard-detail] 모임 상세 조회 REST API 구현

### DIFF
--- a/http/partyboard.http
+++ b/http/partyboard.http
@@ -1,5 +1,28 @@
 
 
+### 모임 검색
+GET http://localhost:8080/partyboards/search
+
+###
+GET http://localhost:8080/partyboards/search?cursor=2&sortMethod=oldest
+
+### 조회순으로 정렬 기준 처음으로 바꿨을 때
+GET http://localhost:8080/partyboards/search?sortMethod=mostViewed
+
+### 관심사 Only
+GET http://localhost:8080/partyboards/search?isLikedOnly=true
+
+###
+GET http://localhost:8080/partyboards/search?cursor=1&isLikedOnly=true
+
+### 마지막 출력 카드번호 6번, 관심사 해당 모임만 출력, 조회수순
+GET http://localhost:8080/partyboards/search?cursor=6&isLikedOnly=true&sortMethod=mostViewed
+
+
+### 모임 상세 조회
+GET http://localhost:8080/partyboards/20
+
+
 ### 모임 글 작성
 POST http://localhost:8080/partyboards
 Content-Type: application/json;charset=utf-8

--- a/src/main/java/com/senials/common/mapper/PartyBoardMapper.java
+++ b/src/main/java/com/senials/common/mapper/PartyBoardMapper.java
@@ -2,6 +2,8 @@ package com.senials.common.mapper;
 
 import com.senials.partyboard.dto.PartyBoardDTOForDetail;
 import com.senials.partyboard.entity.PartyBoard;
+import com.senials.partyboardimage.dto.PartyBoardImageDTO;
+import com.senials.partyboardimage.entity.PartyBoardImage;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
@@ -9,5 +11,7 @@ import org.mapstruct.ReportingPolicy;
 public interface PartyBoardMapper {
 
     PartyBoardDTOForDetail toPartyBoardDTOForDetail(PartyBoard partyBoard);
+
+    PartyBoardImageDTO toPartyBoardImageDTO(PartyBoardImage partyBoardImage);
 
 }

--- a/src/main/java/com/senials/favorites/repository/FavoritesRepository.java
+++ b/src/main/java/com/senials/favorites/repository/FavoritesRepository.java
@@ -1,9 +1,15 @@
 package com.senials.favorites.repository;
 
 import com.senials.favorites.entity.Favorites;
+import com.senials.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface FavoritesRepository extends JpaRepository<Favorites, Integer> {
+
+    List<Favorites> findAllByUser(User user);
+
 }

--- a/src/main/java/com/senials/partyboard/repository/PartyBoardRepository.java
+++ b/src/main/java/com/senials/partyboard/repository/PartyBoardRepository.java
@@ -1,10 +1,21 @@
 package com.senials.partyboard.repository;
 
+import com.senials.hobbyboard.entity.Hobby;
 import com.senials.partyboard.entity.PartyBoard;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PartyBoardRepository extends JpaRepository<PartyBoard, Integer>, JpaSpecificationExecutor<PartyBoard> {
+
+    // 모임 상세 조회
+    PartyBoard findByPartyBoardNumber(int partyBoardNumber);
+
+    Page<PartyBoard> findAllByHobbyIn(List<Hobby> hobby, Pageable pageable);
+
 }


### PR DESCRIPTION
## 이슈
- Resolve #3 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/2874ed94-a43f-4dc7-9e31-f7a2517b8e65)


## 📝작업 내용
- 모임 상세 조회 REST API 구현
- 모임 검색 누락 코드 추가
  - PartyBoardController, PartyBoardService


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/4688b465-7fbb-40a5-9a46-2f61f72fa361)

![image](https://github.com/user-attachments/assets/15a1b865-440c-4d94-9824-f97a5ea255a4)

