### PR TITLE
[feature/backend-37/users/get-user-calender] 회원별 모임 일정 조회 Rest api 기능 구현

### DIFF
--- a/src/main/java/com/senials/meet/MeetDTO/MeetDTO.java
+++ b/src/main/java/com/senials/meet/MeetDTO/MeetDTO.java
@@ -1,0 +1,34 @@
+package com.senials.meet.MeetDTO;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class MeetDTO {
+    private int meetNumber;
+    private LocalDate meetStartDate;
+    private LocalDate meetEndDate;
+    private LocalTime meetStartTime;
+    private LocalTime meetFinishTime;
+    private int meetEntryFee;
+    private String meetLocation;
+    private int meetMaxMember;
+
+    public MeetDTO(int meetNumber, LocalDate meetStartDate, LocalDate meetEndDate, LocalTime meetStartTime,
+                   LocalTime meetFinishTime, int meetEntryFee, String meetLocation, int meetMaxMember) {
+        this.meetNumber = meetNumber;
+        this.meetStartDate = meetStartDate;
+        this.meetEndDate = meetEndDate;
+        this.meetStartTime = meetStartTime;
+        this.meetFinishTime = meetFinishTime;
+        this.meetEntryFee = meetEntryFee;
+        this.meetLocation = meetLocation;
+        this.meetMaxMember = meetMaxMember;
+    }
+}

--- a/src/main/java/com/senials/meet/controller/MeetController.java
+++ b/src/main/java/com/senials/meet/controller/MeetController.java
@@ -1,0 +1,28 @@
+package com.senials.meet.controller;
+
+import com.senials.meet.MeetDTO.MeetDTO;
+import com.senials.meet.service.MeetService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users/{userNumber}/meets")
+public class MeetController {
+
+    private final MeetService meetService;
+
+    public MeetController(MeetService meetService) {
+        this.meetService = meetService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MeetDTO>> getUserMeets(@PathVariable int userNumber) {
+        List<MeetDTO> meets = meetService.getMeetsByUserNumber(userNumber);
+        return ResponseEntity.ok(meets);
+    }
+}

--- a/src/main/java/com/senials/meet/repository/MeetRepository.java
+++ b/src/main/java/com/senials/meet/repository/MeetRepository.java
@@ -2,6 +2,13 @@ package com.senials.meet.repository;
 
 import com.senials.meet.entity.Meet;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MeetRepository extends JpaRepository<Meet, Integer> {
+
+    //사용자 별 참여한 모임 확인
+    @Query("SELECT m FROM Meet m JOIN m.partyBoard pb WHERE pb.user.userNumber = :userNumber")
+    List<Meet> findAllByUserNumber(int userNumber);
 }

--- a/src/main/java/com/senials/meet/service/MeetService.java
+++ b/src/main/java/com/senials/meet/service/MeetService.java
@@ -1,0 +1,34 @@
+package com.senials.meet.service;
+
+import com.senials.meet.MeetDTO.MeetDTO;
+import com.senials.meet.entity.Meet;
+import com.senials.meet.repository.MeetRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class MeetService {
+    private final MeetRepository meetRepository;
+
+    public MeetService(MeetRepository meetRepository) {
+        this.meetRepository = meetRepository;
+    }
+
+    public List<MeetDTO> getMeetsByUserNumber(int userNumber) {
+        List<Meet> meets = meetRepository.findAllByUserNumber(userNumber);
+        return meets.stream()
+                .map(meet -> new MeetDTO(
+                        meet.getMeetNumber(),
+                        meet.getMeetStartDate(),
+                        meet.getMeetEndDate(),
+                        meet.getMeetStartTime(),
+                        meet.getMeetFinishTime(),
+                        meet.getMeetEntryFee(),
+                        meet.getMeetLocation(),
+                        meet.getMeetMaxMember()
+                ))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 이슈
- Resolve #37


## 📁 작업 파일
![스크린샷(8445)](https://github.com/user-attachments/assets/dbe1e616-fa94-4977-88eb-e5614797ed75)


## 📝작업 내용
- 회원별 모임 일정 조회 Rest api
  - GET (/users/{userNumber}/meets)


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![스크린샷(8449)](https://github.com/user-attachments/assets/d3e9c093-7254-4e23-b0d9-f98f8dd3897e)
![스크린샷(8447)](https://github.com/user-attachments/assets/505f5f38-eb59-4385-a1ff-a876ed115746)
![스크린샷(8448)](https://github.com/user-attachments/assets/025cdeed-ab25-4dc3-be40-1d5e0f86090e)
![스크린샷(8446)](https://github.com/user-attachments/assets/601b5aa1-a5e9-4fb7-83b2-844dc94f32de)

## 🚨수정 필요 내용
- 
