### PR TITLE
[feature/backend-38/users/get-user-like] 회원별 좋아요한 모임 조회 Rest api 기능 구현

### DIFF
--- a/src/main/java/com/senials/likes/controller/LikesController.java
+++ b/src/main/java/com/senials/likes/controller/LikesController.java
@@ -1,0 +1,35 @@
+package com.senials.likes.controller;
+
+import com.senials.likes.service.LikesService;
+import com.senials.partyboard.dto.PartyBoardDTOForCard;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+public class LikesController {
+    private final LikesService likesService;
+
+    public LikesController(LikesService likesService) {
+        this.likesService = likesService;
+    }
+
+    // 사용자가 좋아한 모임 목록
+    @GetMapping("/{userNumber}/likes")
+    public ResponseEntity<List<PartyBoardDTOForCard>> getLikedPartyBoards(@PathVariable int userNumber) {
+        List<PartyBoardDTOForCard> likedBoards = likesService.getLikedPartyBoardsByUserNumber(userNumber);
+        return ResponseEntity.ok(likedBoards);
+    }
+
+    //사용자가 좋아한 상태별 모임 목록
+    @GetMapping("/{userNumber}/likes/{partyBoardStatus}")
+    public ResponseEntity<List<PartyBoardDTOForCard>> getLikedPartyBoardsStatus(@PathVariable int userNumber) {
+        List<PartyBoardDTOForCard> likedBoards = likesService.getLikedPartyBoardsByUserNumber(userNumber);
+        return ResponseEntity.ok(likedBoards);
+    }
+}

--- a/src/main/java/com/senials/likes/repository/LikeRepository.java
+++ b/src/main/java/com/senials/likes/repository/LikeRepository.java
@@ -1,9 +1,25 @@
 package com.senials.likes.repository;
 
 import com.senials.likes.entity.Likes;
+import com.senials.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Likes, Integer> {
+
+    // 특정 사용자가 좋아요한 모든 데이터를 상세하게 조회 (PartyReview와 PartyBoardImage 포함)
+    @Query("SELECT l FROM Likes l " +
+            "JOIN FETCH l.partyBoard pb " +
+            "LEFT JOIN FETCH pb.reviews pr " +
+            "LEFT JOIN FETCH pb.images img " +
+            "WHERE l.user = :user")
+    List<Likes> findWithDetailsByUser(@Param("user") User user);
+
+    // 기존 메서드
+    List<Likes> findAllByUser(User user);
 }

--- a/src/main/java/com/senials/likes/service/LikesService.java
+++ b/src/main/java/com/senials/likes/service/LikesService.java
@@ -1,0 +1,63 @@
+package com.senials.likes.service;
+
+import com.senials.common.mapper.PartyBoardMapper;
+import com.senials.common.mapper.PartyBoardMapperImpl;
+import com.senials.likes.entity.Likes;
+import com.senials.likes.repository.LikeRepository;
+import com.senials.partyboard.dto.PartyBoardDTOForCard;
+import com.senials.partyboard.entity.PartyBoard;
+import com.senials.partyreview.entity.PartyReview;
+import com.senials.user.entity.User;
+import com.senials.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LikesService {
+    private final LikeRepository likesRepository;
+    private final UserRepository userRepository;
+    private final PartyBoardMapper partyBoardMapper;
+
+    public LikesService(LikeRepository likesRepository, UserRepository userRepository, PartyBoardMapperImpl partyBoardMapper) {
+        this.likesRepository = likesRepository;
+        this.userRepository = userRepository;
+        this.partyBoardMapper = partyBoardMapper;
+    }
+
+    // 좋아요 한 모임 리스트 가져오기
+    public List<PartyBoardDTOForCard> getLikedPartyBoardsByUserNumber(int userNumber) {
+        User user = userRepository.findById(userNumber)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        List<Likes> likesList = likesRepository.findAllByUser(user);
+
+        return likesList.stream().map(likes -> {
+            PartyBoard partyBoard = likes.getPartyBoard();
+
+            // 별점 평균 계산
+            double averageRating = 0.0;
+            List<PartyReview> reviews = partyBoard.getReviews();
+            if (!reviews.isEmpty()) {
+                int totalRating = 0;
+                for (PartyReview review : reviews) {
+                    totalRating += review.getPartyReviewRate();
+                }
+                averageRating = (double) totalRating / reviews.size();
+            }
+            // 첫 번째 이미지 가져오기
+            String firstImage = partyBoard.getImages().isEmpty() ? null : partyBoard.getImages().get(0).getPartyBoardImg();
+            // DTO 생성
+            return new PartyBoardDTOForCard(
+                    partyBoard.getPartyBoardNumber(),
+                    partyBoard.getPartyBoardName(),
+                    partyBoard.getPartyBoardStatus(),
+                    partyBoard.getPartyMembers().size(), // 참여 인원 수
+                    averageRating,
+                    firstImage
+            );
+        }).collect(Collectors.toList());
+
+    }
+}

--- a/src/main/java/com/senials/partyboard/dto/PartyBoardDTO.java
+++ b/src/main/java/com/senials/partyboard/dto/PartyBoardDTO.java
@@ -1,0 +1,49 @@
+package com.senials.partyboard.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class PartyBoardDTO {
+
+    private int partyBoardNumber; // auto
+
+    private int userNumber;
+
+    private int hobbyNumber;
+
+    private String partyBoardName;
+
+    private String partyBoardDetail;
+
+    private LocalDate partyBoardOpenDate; // now()
+
+    private int partyBoardStatus; // 0-모집중, 1-모집완료
+
+    private int partyBoardViewCnt;
+
+    private int partyBoardLikeCnt;
+
+    private int partyBoardReportCnt;
+
+    /* AllArgsConstructor */
+    public PartyBoardDTO(int partyBoardNumber, int userNumber, int hobbyNumber, String partyBoardName, String partyBoardDetail, LocalDate partyBoardOpenDate, int partyBoardStatus, int partyBoardViewCnt, int partyBoardLikeCnt, int partyBoardReportCnt) {
+        this.partyBoardNumber = partyBoardNumber;
+        this.userNumber = userNumber;
+        this.hobbyNumber = hobbyNumber;
+        this.partyBoardName = partyBoardName;
+        this.partyBoardDetail = partyBoardDetail;
+        this.partyBoardOpenDate = partyBoardOpenDate;
+        this.partyBoardStatus = partyBoardStatus;
+        this.partyBoardViewCnt = partyBoardViewCnt;
+        this.partyBoardLikeCnt = partyBoardLikeCnt;
+        this.partyBoardReportCnt = partyBoardReportCnt;
+    }
+}

--- a/src/main/java/com/senials/partyboard/dto/PartyBoardDTOForCard.java
+++ b/src/main/java/com/senials/partyboard/dto/PartyBoardDTOForCard.java
@@ -1,0 +1,18 @@
+package com.senials.partyboard.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class PartyBoardDTOForCard {
+    private int partyBoardNumber;
+    private String partyBoardName;
+    private int partyBoardStatus;
+    private long memberCount; // 참여 인원 수
+    private double averageRating; // 별점 평균
+    private String firstImage; // 첫 번째 이미지 경로
+}
+


### PR DESCRIPTION
## 이슈
- Resolve #38


## 📁 작업 파일
![스크린샷(8451)](https://github.com/user-attachments/assets/42a49e87-3bcb-4161-9d27-e6a30017450f)


## 📝작업 내용
- 회원별 좋아요한 모임 조회 Rest api
  - GET (/users/{userNumber}/likes)


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![스크린샷(8454)](https://github.com/user-attachments/assets/62ea2f21-b782-4421-833c-7d1a9838201b)
![스크린샷(8452)](https://github.com/user-attachments/assets/9bfd5835-1d97-4507-86c8-83c2603197bb)
![스크린샷(8453)](https://github.com/user-attachments/assets/e7cd91f9-9682-45d9-8b51-d409871ff0b0)
![image](https://github.com/user-attachments/assets/6f6cdcfd-6f09-4e31-8b70-fdcf68f5b6a8)


## 🚨수정 필요 내용
- 
