### PR TITLE
[feature/backend-8/meets/register-meet] 모임 일정 추가 REST API 구현

### DIFF
--- a/http/meet.http
+++ b/http/meet.http
@@ -5,3 +5,18 @@ GET https://examples.http-client.intellij.net/get
 
 ### 모임 내 일정 전체 조회
 GET http://localhost:8080/partyboards/1/meets
+
+### 모임 일정 추가
+POST http://localhost:8080/partyboards/2/meets
+Content-Type: application/json;charset=UTF-8
+
+{
+  "partyBoardNumber": 2,
+  "meetStartDate": "2030-12-15",
+  "meetEndDate": "2030-01-15",
+  "meetStartTime": "14:00",
+  "meetFinishTime": "14:30",
+  "meetEntryFee": 5555,
+  "meetLocation": "testLocationTest",
+  "meetMaxMember": 555
+}

--- a/src/main/java/com/senials/meet/controller/MeetController.java
+++ b/src/main/java/com/senials/meet/controller/MeetController.java
@@ -6,9 +6,7 @@ import com.senials.meet.service.MeetService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -41,6 +39,20 @@ public class MeetController {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "일정 전체 조회 완료", responseMap));
+    }
+
+    /* 모임 일정 추가 */
+    @PostMapping("/partyboards/{partyBoardNumber}/meets")
+    public ResponseEntity<ResponseMessage> registerMeet(
+            @PathVariable Integer partyBoardNumber,
+            @RequestBody MeetDTO meetDTO
+    ) {
+        meetService.registerMeet(partyBoardNumber, meetDTO);
+
+        // ResponseHeader 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "일정 추가 완료", null));
     }
 
         

--- a/src/main/java/com/senials/meet/entity/Meet.java
+++ b/src/main/java/com/senials/meet/entity/Meet.java
@@ -70,4 +70,10 @@ public class Meet {
         this.meetMaxMember = meetMaxMember;
     }
 
+
+    /* Meet 생성 시 partyBoard 연결 용 */
+    public void initializePartyBoard(PartyBoard partyBoard) {
+        this.partyBoard = partyBoard;
+    }
+
 }

--- a/src/main/java/com/senials/meet/service/MeetService.java
+++ b/src/main/java/com/senials/meet/service/MeetService.java
@@ -9,6 +9,7 @@ import com.senials.partyboard.entity.PartyBoard;
 import com.senials.partyboard.repository.PartyBoardRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,6 +47,22 @@ public class MeetService {
         List<MeetDTO> meetDTOList = meetList.stream().map(meetMapper::toMeetDTO).toList();
 
         return meetDTOList;
+    }
+
+
+    /* 모임 일정 추가 */
+    @Transactional
+    public void registerMeet(int partyBoardNumber, MeetDTO meetDTO) {
+
+        PartyBoard partyBoard = partyBoardRepository.findById(partyBoardNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+        Meet meet = meetMapper.toMeet(meetDTO);
+
+        /* PartyBoard 엔티티 연결 */
+        meet.initializePartyBoard(partyBoard);
+
+        meetRepository.save(meet);
     }
 
   


### PR DESCRIPTION
## 이슈
- Resolve #8 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/e1049bf3-e1c4-4640-a991-64d30f266d43)


## 📝작업 내용
- 특정 모임 내 일정을 추가하는 API를 구현한다.


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
- ### 코드 MeetService
![image](https://github.com/user-attachments/assets/c1699963-662e-44aa-99f9-1460187101dc)
- ### 호출
![image](https://github.com/user-attachments/assets/9ec581c9-c29e-4472-ad1b-a01c1024924c)
- ### Response 결과
![image](https://github.com/user-attachments/assets/9596bed5-278a-4a1b-a5ff-135a19dc7aea)


## 🚨수정 필요 내용
- 
