### PR TITLE
[feature/backend-27/hobbyreview/delete-hobbyreview] 취미 게시판 취미 후기 삭제 Rest api 기능 구현

### DIFF
--- a/http/hobbyTest.http
+++ b/http/hobbyTest.http
@@ -8,7 +8,7 @@ GET http://localhost:8081/hobby-detail/1
 GET http://localhost:8081/hobby-board/3
 
 ###취미 게시판 후기 조회
-GET http://localhost:8081/1/hobby-review/13
+GET http://localhost:8081/1/hobby-review/17
 
 ###취미 게시판 후기 작성
 POST http://localhost:8081/1/hobby-review
@@ -16,9 +16,12 @@ Content-Type: application/json;charset=UTF-8
 
 {
   "hobbyReviewRate": 4,
-  "hobbyReviewDetail": "데이터 테스트",
+  "hobbyReviewDetail": "데이터 삭제 테스트",
   "hobbyReviewHealthStatus": 1,
   "hobbyReviewTendency": 1,
   "hobbyReviewLevel": 3,
   "hobbyReviewWriteDate": "2024-12-02"
 }
+
+###취미 게시판 후기 삭제
+DELETE http://localhost:8081/1/hobby-review/13

--- a/src/main/java/com/senials/hobbyreview/controller/HobbyReviewController.java
+++ b/src/main/java/com/senials/hobbyreview/controller/HobbyReviewController.java
@@ -56,4 +56,28 @@ public class HobbyReviewController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(201, "생성 성공", responseMap));
     }
 
+    //취미 후기 삭제
+    @DeleteMapping("/{hobbyNumber}/hobby-review/{hobbyReviewNumber}")
+    public ResponseEntity<ResponseMessage> deleteHobbyReview(
+            @PathVariable("hobbyNumber") int hobbyNumber,
+            @PathVariable("hobbyReviewNumber") int hobbyReviewNumber) {
+        try {
+            hobbyReviewService.deleteHobbyReview(hobbyReviewNumber, userNumber, hobbyNumber);
+
+            Map<String, Object> responseMap = new HashMap<>();
+            responseMap.put("message", "삭제 성공");
+
+            return ResponseEntity.ok()
+                    .headers(httpHeadersFactory.createJsonHeaders())
+                    .body(new ResponseMessage(204, "삭제 성공", responseMap));
+        } catch (IllegalArgumentException e) {
+            Map<String, Object> errorMap = new HashMap<>();
+            errorMap.put("message", e.getMessage());
+
+            return ResponseEntity.badRequest()
+                    .headers(httpHeadersFactory.createJsonHeaders())
+                    .body(new ResponseMessage(400, "삭제 실패", errorMap));
+        }
+    }
+
 }

--- a/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
+++ b/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
@@ -18,20 +18,20 @@ public class HobbyReviewService {
     private final HobbyRepository hobbyRepository;
     private final UserRepository userRepository;
 
-    HobbyReviewService(HobbyReviewRepository hobbyReviewRepository, HobbyReviewMapper hobbyReviewMapper, HobbyRepository hobbyRepository, UserRepository userRepository){
-        this.hobbyReviewMapper=hobbyReviewMapper;
-        this.hobbyReviewRepository=hobbyReviewRepository;
-        this.hobbyRepository=hobbyRepository;
-        this.userRepository=userRepository;
+    HobbyReviewService(HobbyReviewRepository hobbyReviewRepository, HobbyReviewMapper hobbyReviewMapper, HobbyRepository hobbyRepository, UserRepository userRepository) {
+        this.hobbyReviewMapper = hobbyReviewMapper;
+        this.hobbyReviewRepository = hobbyReviewRepository;
+        this.hobbyRepository = hobbyRepository;
+        this.userRepository = userRepository;
     }
 
     //취미 번호가 같은 취미리뷰 리스트 불러오기
     public List<HobbyReviewDTO> getReviewsListByHobbyNumber(int hobbyNumber) {
         Hobby hobby = hobbyRepository.findById(hobbyNumber)
                 .orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
-        List<HobbyReview> hobbyReviewList=hobbyReviewRepository.findByHobby(hobby);
-        List<HobbyReviewDTO> hobbyReviewDTOList=hobbyReviewList.stream().map(hobbyReview -> {
-            HobbyReviewDTO dto=hobbyReviewMapper.toHobbyReviewDTO(hobbyReview);
+        List<HobbyReview> hobbyReviewList = hobbyReviewRepository.findByHobby(hobby);
+        List<HobbyReviewDTO> hobbyReviewDTOList = hobbyReviewList.stream().map(hobbyReview -> {
+            HobbyReviewDTO dto = hobbyReviewMapper.toHobbyReviewDTO(hobbyReview);
             dto.setHobbyNumber(hobbyReview.getHobby().getHobbyNumber());
             dto.setUserNumber(hobbyReview.getUser().getUserNumber());
             dto.setUserName(hobbyReview.getUser().getUserName());
@@ -41,18 +41,19 @@ public class HobbyReviewService {
     }
 
     //취미번호, 유저번호, 리뷰번호를 통한 대조후 취미리뷰 조회
-    public HobbyReviewDTO getHobbyReview(int hobbyNumber, int userNumber, int hobbyReviewNumber){
-        User user= (User) userRepository.findById(userNumber).orElseThrow(() -> new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: " + userNumber));;
-        Hobby hobby=hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
+    public HobbyReviewDTO getHobbyReview(int hobbyNumber, int userNumber, int hobbyReviewNumber) {
+        User user = (User) userRepository.findById(userNumber).orElseThrow(() -> new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: " + userNumber));
+        ;
+        Hobby hobby = hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
         HobbyReview hobbyReview = hobbyReviewRepository.findById(hobbyReviewNumber).orElseThrow(() -> new IllegalArgumentException("해당 리뷰 번호가 존재하지 않습니다: " + hobbyReviewNumber));
-        if(!hobbyReview.getUser().equals(user)){
+        if (!hobbyReview.getUser().equals(user)) {
             throw new IllegalArgumentException("해당 유저의 리뷰가 아닙니다.");
         }
         if
         (!hobbyReview.getHobby().equals(hobby)) {
             throw new IllegalArgumentException("해당 취미의 리뷰가 아닙니다.");
         }
-        HobbyReviewDTO hobbyReviewDTO=hobbyReviewMapper.toHobbyReviewDTO(hobbyReview);
+        HobbyReviewDTO hobbyReviewDTO = hobbyReviewMapper.toHobbyReviewDTO(hobbyReview);
         hobbyReviewDTO.setHobbyNumber(hobby.getHobbyNumber());
         hobbyReviewDTO.setUserNumber(user.getUserNumber());
         hobbyReviewDTO.setUserName(hobbyReview.getUser().getUserName());
@@ -62,13 +63,32 @@ public class HobbyReviewService {
 
     //취미 번호와 유저 번호를 통해 취미후기를 생성
     public HobbyReview saveHobbyReview(HobbyReviewDTO hobbyReviewDTO, int userNumber, int hobbyNumber) {
-        User user= userRepository.findById(userNumber).orElseThrow(() -> new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: " + userNumber));;
-        Hobby hobby=hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
+        User user = userRepository.findById(userNumber).orElseThrow(() -> new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: " + userNumber));
+        ;
+        Hobby hobby = hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
         HobbyReview hobbyReviewEntity = hobbyReviewMapper.toHobbyReviewEntity(hobbyReviewDTO);
         hobbyReviewEntity.InitializeUser(user);
         hobbyReviewEntity.InitializeHobby(hobby);
-        HobbyReview hobbyReview=hobbyReviewRepository.save(hobbyReviewEntity);
+        HobbyReview hobbyReview = hobbyReviewRepository.save(hobbyReviewEntity);
 
         return hobbyReview;
     }
+
+    //취미번호, 유저번호, 리뷰번호를 통한 대조후 취미리뷰 삭제
+    public void deleteHobbyReview(int hobbyReviewNumber, int userNumber, int hobbyNumber){
+        User user= userRepository.findById(userNumber).orElseThrow(() -> new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: " + userNumber));;
+        Hobby hobby=hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
+        HobbyReview hobbyReview = hobbyReviewRepository.findById(hobbyReviewNumber).orElseThrow(() -> new IllegalArgumentException("해당 리뷰 번호가 존재하지 않습니다: " + hobbyReviewNumber));
+        if(!hobbyReview.getUser().equals(user)){
+            throw new IllegalArgumentException("해당 유저의 리뷰가 아닙니다.");
+        }
+        if
+        (!hobbyReview.getHobby().equals(hobby)) {
+            throw new IllegalArgumentException("해당 취미의 리뷰가 아닙니다.");
+        }
+
+        hobbyReviewRepository.delete(hobbyReview);
+    }
+
 }
+


### PR DESCRIPTION
## 이슈
- #27 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/50e82ded-fa90-42ba-95cf-e36b2f41035d)


## 📝작업 내용
- 취미 게시판 취미 후기 삭제 Rest api 기능 구현
  - service HobbyReviewService deleteHobbyReview() 메소드 추가, 취미번호, 유저번호, 리뷰번호를 통한 대조후 취미리뷰 삭제
  - controller HobbyReviewController deleteHobbyReview() 메소드추가 및 연동, 취미 후기 삭제

## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/34312fde-bb8e-4f57-bb34-36f8facce181)
![image](https://github.com/user-attachments/assets/5f98d878-d8be-4b06-bdf6-0a0b4564bea4)
![image](https://github.com/user-attachments/assets/254d7e5e-b28a-4c2b-a220-d559460fb3b7)
![image](https://github.com/user-attachments/assets/2c979091-53ed-44b7-a930-8c2e73f03b9f)
![image](https://github.com/user-attachments/assets/6d6d89b8-4f77-4bdd-ada7-e771d07fb917)





## 🚨수정 필요 내용
- 
