### PR TITLE
[Feature/backend-39/users/get-user-parties] 회원별 참여한 모임 조회 Rest api 기능 구현

### DIFF
--- a/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
+++ b/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
@@ -3,5 +3,9 @@ package com.senials.partymember.repository;
 import com.senials.partymember.entity.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Integer> {
+    List<PartyMember> findByUser_UserNumber(int userNumber); // 사용자별 참여 데이터 조회
+
 }

--- a/src/main/java/com/senials/user/controller/UserController.java
+++ b/src/main/java/com/senials/user/controller/UserController.java
@@ -113,6 +113,9 @@ public class UserController {
     public ResponseEntity<ResponseMessage> getUserJoinedPartyBoards(@PathVariable int userNumber) {
         // Service 호출
         List<PartyBoardDTOForCard> joinedParties = userService.getJoinedPartyBoardsByUserNumber(userNumber);
+        // ResponseHeader 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
 
         if (joinedParties.isEmpty()) {
             return ResponseEntity.status(404)
@@ -121,10 +124,9 @@ public class UserController {
 
         // 응답 데이터 생성
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("userNumber", userNumber);
         responseMap.put("joinedParties", joinedParties);
 
-        return ResponseEntity.ok(
+        return ResponseEntity.ok().headers(headers).body(
                 new ResponseMessage(200, "사용자가 참여한 모임 조회 성공", responseMap)
         );
     }

--- a/src/main/java/com/senials/user/controller/UserController.java
+++ b/src/main/java/com/senials/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.senials.user.controller;
 
 import com.senials.common.ResponseMessage;
+import com.senials.partyboard.dto.PartyBoardDTOForCard;
 import com.senials.user.dto.UserCommonDTO;
 import com.senials.user.dto.UserDTO;
 import com.senials.user.service.UserService;
@@ -102,5 +103,29 @@ public class UserController {
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(new ResponseMessage(200, "사용자 프로필 수정 성공", null));
+    }
+
+
+
+    //사용자 별 참여한 모임 출력
+    // 사용자별 참여 모임 목록 조회
+    @GetMapping("/{userNumber}/parties")
+    public ResponseEntity<ResponseMessage> getUserJoinedPartyBoards(@PathVariable int userNumber) {
+        // Service 호출
+        List<PartyBoardDTOForCard> joinedParties = userService.getJoinedPartyBoardsByUserNumber(userNumber);
+
+        if (joinedParties.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(new ResponseMessage(404, "사용자가 참여한 모임이 없습니다.", null));
+        }
+
+        // 응답 데이터 생성
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("userNumber", userNumber);
+        responseMap.put("joinedParties", joinedParties);
+
+        return ResponseEntity.ok(
+                new ResponseMessage(200, "사용자가 참여한 모임 조회 성공", responseMap)
+        );
     }
 }

--- a/src/main/java/com/senials/user/service/UserService.java
+++ b/src/main/java/com/senials/user/service/UserService.java
@@ -1,7 +1,12 @@
 package com.senials.user.service;
 
 import com.senials.common.mapper.UserMapper;
+import com.senials.partyboard.dto.PartyBoardDTOForCard;
+import com.senials.partyboard.entity.PartyBoard;
 import com.senials.partyboard.repository.PartyBoardRepository;
+import com.senials.partymember.entity.PartyMember;
+import com.senials.partymember.repository.PartyMemberRepository;
+import com.senials.partyreview.entity.PartyReview;
 import com.senials.user.dto.UserCommonDTO;
 import com.senials.user.dto.UserDTO;
 import com.senials.user.entity.User;
@@ -9,6 +14,7 @@ import com.senials.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class UserService {
@@ -17,9 +23,12 @@ public class UserService {
 
     private com.senials.user.repository.UserRepository userRepository;
 
-    public UserService(UserMapper userMapper, UserRepository userRepository) {
+    private final PartyMemberRepository partyMemberRepository;
+
+    public UserService(UserMapper userMapper, UserRepository userRepository, PartyMemberRepository partyMemberRepository) {
         this.userMapper = userMapper;
         this.userRepository = userRepository;
+        this.partyMemberRepository = partyMemberRepository;
     }
 
     //모든 사용자 조회
@@ -66,4 +75,36 @@ public class UserService {
         }).orElseThrow(IllegalArgumentException::new);
     }
 
+    //사용자별 참여한 모임 출력
+    // 사용자별 참여한 모임 목록을 PartyBoardDTOForCard로 반환
+    public List<PartyBoardDTOForCard> getJoinedPartyBoardsByUserNumber(int userNumber) {
+        // 사용자가 참여한 PartyMember 목록 조회
+        List<PartyMember> partyMembers = partyMemberRepository.findByUser_UserNumber(userNumber);
+
+        // PartyBoardDTOForCard 리스트로 변환
+        return partyMembers.stream()
+                .map(pm -> {
+                    PartyBoard partyBoard = pm.getPartyBoard();
+                    // 별점 평균 계산
+                    double averageRating = 0.0;
+                    List<PartyReview> reviews = partyBoard.getReviews();
+                    if (!reviews.isEmpty()) {
+                        int totalRating = reviews.stream().mapToInt(PartyReview::getPartyReviewRate).sum();
+                        averageRating = (double) totalRating / reviews.size();
+                    }
+
+                    // 첫 번째 이미지 가져오기
+                    String firstImage = partyBoard.getImages().isEmpty() ? null : partyBoard.getImages().get(0).getPartyBoardImg();
+
+                    // DTO 생성
+                    return new PartyBoardDTOForCard(
+                            partyBoard.getPartyBoardNumber(),
+                            partyBoard.getPartyBoardName(),
+                            partyBoard.getPartyBoardStatus(),
+                            partyBoard.getPartyMembers().size(), // 참여 인원 수
+                            averageRating,
+                            firstImage
+                    );
+                }).collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 이슈
- Resolve #39


## 📁 작업 파일
![스크린샷(8456)](https://github.com/user-attachments/assets/70a43c7f-a32e-4c3b-83de-13bff2789a4d)


## 📝작업 내용
- 회원별 참여한 모임 조회 Rest api 기능 구현
  - GET (/users/{userNumber}/parties)


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![스크린샷(8457)](https://github.com/user-attachments/assets/7626aaf8-82e8-4f45-8df9-0cef4e363215)
![스크린샷(8458)](https://github.com/user-attachments/assets/d2da719c-555b-4036-a0a2-c8d7415e5b6a)
![image](https://github.com/user-attachments/assets/2a63ed57-9384-4025-a89b-21b3f7f6ee53)


## 🚨수정 필요 내용
- 
