### PR TITLE
[feature/backend-40/users/get-user-made] 회원별 생성 모임 조회 Rest api 기능 구현

### DIFF
--- a/src/main/java/com/senials/user/controller/UserController.java
+++ b/src/main/java/com/senials/user/controller/UserController.java
@@ -130,4 +130,28 @@ public class UserController {
                 new ResponseMessage(200, "사용자가 참여한 모임 조회 성공", responseMap)
         );
     }
+
+    //사용자 별 자신이 만든 모임 조회
+    @GetMapping("/{userNumber}/made")
+    public ResponseEntity<ResponseMessage> getUserMadeParties(@PathVariable int userNumber) {
+        // UserService에서 리스트로 결과를 가져옴
+        List<PartyBoardDTOForCard> madeParties = userService.getMadePartyBoardsByUserNumber(userNumber);
+
+        // ResponseHeader 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        if (madeParties.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(new ResponseMessage(404, "사용자가 만든 모임이 없습니다.", null));
+        }
+
+        // 성공
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("madeParties", madeParties);
+
+        return ResponseEntity.ok().headers(headers).body(
+                new ResponseMessage(200, "사용자가 만든 모임 조회 성공", responseMap)
+        );
+    }
 }

--- a/src/main/java/com/senials/user/service/UserService.java
+++ b/src/main/java/com/senials/user/service/UserService.java
@@ -107,4 +107,40 @@ public class UserService {
                     );
                 }).collect(Collectors.toList());
     }
+    // 사용자가 만든 모임 목록 조회
+    public List<PartyBoardDTOForCard> getMadePartyBoardsByUserNumber(int userNumber) {
+        // User가 만든 PartyBoard 목록을 직접 조회
+        User user = userRepository.findById(userNumber)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        List<PartyBoard> partyBoards = user.getPartyBoards(); // User와 PartyBoard가 연결되어 있다고 가정
+
+        return partyBoards.stream().map(partyBoard -> {
+            // 별점 평균 계산
+            double averageRating = 0.0;
+            List<PartyReview> reviews = partyBoard.getReviews(); // PartyBoard에 PartyReview 관계가 있다고 가정
+
+            if (!reviews.isEmpty()) {
+                int totalRating = 0;
+                for (PartyReview review : reviews) {
+                    totalRating += review.getPartyReviewRate();
+                }
+                averageRating = (double) totalRating / reviews.size();
+            }
+
+            // 첫 번째 이미지 가져오기
+            String firstImage = partyBoard.getImages().isEmpty() ? null : partyBoard.getImages().get(0).getPartyBoardImg();
+
+            // DTO 생성
+            return new PartyBoardDTOForCard(
+                    partyBoard.getPartyBoardNumber(),
+                    partyBoard.getPartyBoardName(),
+                    partyBoard.getPartyBoardStatus(),
+                    partyBoard.getPartyMembers().size(), // 참여 인원 수
+                    averageRating,
+                    firstImage
+            );
+        }).collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
## 이슈
- Resolve #40


## 📁 작업 파일
![스크린샷(8460)](https://github.com/user-attachments/assets/73e51d80-19e1-4bb3-84bb-4b75668c6650)


## 📝작업 내용
- 회원별 생성 모임 조회 Rest api 기능 구현
  - GET (/users/{userNumber}/made)


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![스크린샷(8461)](https://github.com/user-attachments/assets/23f84be1-bff4-42f0-a89a-6c7e75ea639b)
![스크린샷(8462)](https://github.com/user-attachments/assets/28e3375f-fffe-45d6-a451-78cb7c223fea)
![스크린샷(8463)](https://github.com/user-attachments/assets/84ae68a7-347d-4b34-84d5-379be8747bdc)


## 🚨수정 필요 내용
- 
