### PR TITLE
[feature/backend-28/hobbyreview/put-hobbyreview] 취미 게시판 특정 취미 후기 수정 Rest api 기능 구현

### DIFF
--- a/http/hobbyTest.http
+++ b/http/hobbyTest.http
@@ -25,3 +25,16 @@ Content-Type: application/json;charset=UTF-8
 
 ###취미 게시판 후기 삭제
 DELETE http://localhost:8081/1/hobby-review/13
+
+###취미 게시판 후기 수정
+PUT http://localhost:8081/1/hobby-review/13
+Content-Type: application/json;charset=UTF-8
+
+{
+  "hobbyReviewRate": 2,
+  "hobbyReviewDetail": "이게무야",
+  "hobbyReviewHealthStatus": 3,
+  "hobbyReviewTendency": 2,
+  "hobbyReviewLevel": 1,
+  "hobbyReviewWriteDate": "2024-12-02"
+}

--- a/src/main/java/com/senials/hobbyreview/controller/HobbyReviewController.java
+++ b/src/main/java/com/senials/hobbyreview/controller/HobbyReviewController.java
@@ -80,4 +80,29 @@ public class HobbyReviewController {
         }
     }
 
+    //취미 후기 수정
+    @PutMapping("{hobbyNumber}/hobby-review/{hobbyReviewNumber}")
+    public ResponseEntity<ResponseMessage> updateHobbyReview(
+            @PathVariable("hobbyNumber") int hobbyNumber,
+            @PathVariable("hobbyReviewNumber") int hobbyReviewNumber,
+            @RequestBody HobbyReviewDTO hobbyReviewDTO) {
+        try {
+            hobbyReviewService.updateHobbyReview(hobbyReviewDTO,hobbyReviewNumber, userNumber, hobbyNumber);
+
+            Map<String, Object> responseMap = new HashMap<>();
+            responseMap.put("message", "수정 성공");
+
+            return ResponseEntity.ok()
+                    .headers(httpHeadersFactory.createJsonHeaders())
+                    .body(new ResponseMessage(200, "수정 성공", responseMap));
+        } catch (IllegalArgumentException e) {
+            Map<String, Object> errorMap = new HashMap<>();
+            errorMap.put("message", e.getMessage());
+
+            return ResponseEntity.badRequest()
+                    .headers(httpHeadersFactory.createJsonHeaders())
+                    .body(new ResponseMessage(400, "수정 실패", errorMap));
+        }
+    }
+
 }

--- a/src/main/java/com/senials/hobbyreview/entity/HobbyReview.java
+++ b/src/main/java/com/senials/hobbyreview/entity/HobbyReview.java
@@ -69,4 +69,24 @@ public class HobbyReview {
         this.user=user;
     }
 
+    public void updateHobbyReviewRate(int hobbyReviewRate) {
+        this.hobbyReviewRate = hobbyReviewRate;
+    }
+
+    public void updateHobbyReviewDetail(String hobbyReviewDetail) {
+        this.hobbyReviewDetail = hobbyReviewDetail;
+    }
+
+    public void updateHobbyReviewHealthStatus(int hobbyReviewHealthStatus) {
+        this.hobbyReviewHealthStatus = hobbyReviewHealthStatus;
+    }
+
+    public void updateHobbyReviewTendency(int hobbyReviewTendency) {
+        this.hobbyReviewTendency = hobbyReviewTendency;
+    }
+
+    public void updateHobbyReviewLevel(int hobbyReviewLevel) {
+        this.hobbyReviewLevel = hobbyReviewLevel;
+    }
+
 }

--- a/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
+++ b/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
@@ -90,5 +90,27 @@ public class HobbyReviewService {
         hobbyReviewRepository.delete(hobbyReview);
     }
 
+    //취미번호, 유저번호, 리뷰번호를 통한 대조후 취미리뷰 수정
+    public HobbyReview updateHobbyReview(HobbyReviewDTO hobbyReviewDTO, int hobbyReviewNumber, int userNumber, int hobbyNumber) {
+        User user = (User) userRepository.findById(userNumber).orElseThrow(() -> new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: " + userNumber));
+        Hobby hobby = hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));
+        HobbyReview hobbyReview = hobbyReviewRepository.findById(hobbyReviewNumber).orElseThrow(() -> new IllegalArgumentException("해당 리뷰 번호가 존재하지 않습니다: " + hobbyReviewNumber));
+        if (!hobbyReview.getUser().equals(user)) {
+            throw new IllegalArgumentException("해당 유저의 리뷰가 아닙니다.");
+        }
+        if
+        (!hobbyReview.getHobby().equals(hobby)) {
+            throw new IllegalArgumentException("해당 취미의 리뷰가 아닙니다.");
+        }
+
+        hobbyReview.updateHobbyReviewRate(hobbyReviewDTO.getHobbyReviewRate());
+        hobbyReview.updateHobbyReviewDetail(hobbyReviewDTO.getHobbyReviewDetail());
+        hobbyReview.updateHobbyReviewHealthStatus(hobbyReviewDTO.getHobbyReviewHealthStatus());
+        hobbyReview.updateHobbyReviewTendency(hobbyReviewDTO.getHobbyReviewTendency());
+        hobbyReview.updateHobbyReviewLevel(hobbyReviewDTO.getHobbyReviewLevel());
+
+        return hobbyReviewRepository.save(hobbyReview);
+    }
+
 }
 


### PR DESCRIPTION
## 이슈
- #28 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/95f6b48e-72ef-4e19-8b17-d10995e6ad82)


## 📝작업 내용
- 취미 게시판 특정 취미 후기 수정 Rest api 기능 구현
  - entity HobbyReview updateHobby~() 4개 메소드 추가
  - service HobbyReviewService updateHobbyReview() 메소드 추가, 취미번호, 유저번호, 리뷰번호를 통한 대조후 취미리뷰 수정
  - controller HobbyReviewController updateHobbyReview() 메소드 추가 및 연동,  취미 후기 수정


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/bef5e8e1-7fad-47fa-bf34-05d85c282973)
![image](https://github.com/user-attachments/assets/5e1ad8b9-85f3-4cf4-94f6-49f48094e666)
![image](https://github.com/user-attachments/assets/c31c9bdf-9713-4559-8062-5dec85572574)
![image](https://github.com/user-attachments/assets/a4a9868f-2468-4e6d-a19f-fdb3e659d2ed)
![image](https://github.com/user-attachments/assets/ed41f575-7376-4557-82e9-c2d322358bd7)
![image](https://github.com/user-attachments/assets/a6be3d06-0d8b-4838-8652-9a509c6d752a)






## 🚨수정 필요 내용
- 
