### PR TITLE
[feature/backend-11/meetmembers/get-all-meetmembers] 모임 일정 참여멤버 조회 REST API 구현

### DIFF
--- a/http/meet.http
+++ b/http/meet.http
@@ -38,3 +38,7 @@ Content-Type: application/json;charset=UTF-8
 
 ### 모임 일정 삭제
 DELETE http://localhost:8080/partyboards/2/meets/7
+
+
+### 모임 일정 참여멤버 조회
+GET http://localhost:8080/partyboards/1/meets/1/meetmembers

--- a/src/main/java/com/senials/common/mapper/UserMapper.java
+++ b/src/main/java/com/senials/common/mapper/UserMapper.java
@@ -2,6 +2,7 @@ package com.senials.common.mapper;
 
 
 import com.senials.user.dto.UserDTO;
+import com.senials.user.dto.UserDTOForPublic;
 import com.senials.user.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
@@ -11,5 +12,8 @@ public interface UserMapper {
 
     // User -> UserDTO
     UserDTO toUserDTO(User user);
+
+    /* User -> UserDTOForPublic */
+    UserDTOForPublic toUserDTOForPublic(User user);
 
 }

--- a/src/main/java/com/senials/meet/controller/MeetController.java
+++ b/src/main/java/com/senials/meet/controller/MeetController.java
@@ -2,14 +2,12 @@ package com.senials.meet.controller;
 
 import com.senials.common.ResponseMessage;
 import com.senials.meet.dto.MeetDTO;
-import com.senials.meet.entity.Meet;
 import com.senials.meet.repository.MeetRepository;
 import com.senials.meet.service.MeetService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/com/senials/meetmember/controller/MeetMemberController.java
+++ b/src/main/java/com/senials/meetmember/controller/MeetMemberController.java
@@ -1,0 +1,58 @@
+package com.senials.meetmember.controller;
+
+import com.senials.common.ResponseMessage;
+import com.senials.common.mapper.UserMapper;
+import com.senials.meet.repository.MeetRepository;
+import com.senials.meetmember.repository.MeetMemberRepository;
+import com.senials.meetmember.service.MeetMemberService;
+import com.senials.user.dto.UserDTOForPublic;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+public class MeetMemberController {
+
+
+    private final UserMapper userMapper;
+    private final MeetRepository meetRepository;
+    private final MeetMemberRepository meetMemberRepository;
+    private final MeetMemberService meetMemberService;
+
+    public MeetMemberController(
+            UserMapper userMapper
+            , MeetRepository meetRepository
+            , MeetMemberRepository meetMemberRepository
+            , MeetMemberService meetMemberService
+    ) {
+        this.userMapper = userMapper;
+        this.meetRepository = meetRepository;
+        this.meetMemberRepository = meetMemberRepository;
+        this.meetMemberService = meetMemberService;
+    }
+
+    /* 모임 일정 참여멤버 조회 */
+    @GetMapping("/partyboards/{partyBoardNumber}/meets/{meetNumber}/meetmembers")
+    public ResponseEntity<ResponseMessage> getMeetMembersByMeetNumber(
+            @PathVariable Integer meetNumber
+    ) {
+        List<UserDTOForPublic> meetMemberList = meetMemberService.getMeetMembersByMeetNumber(meetNumber);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("meetMembers", meetMemberList);
+
+        // ResponseHeader 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "일정 참여멤버 조회 성공", responseMap));
+    }
+
+}

--- a/src/main/java/com/senials/meetmember/repository/MeetMemberRepository.java
+++ b/src/main/java/com/senials/meetmember/repository/MeetMemberRepository.java
@@ -1,7 +1,13 @@
 package com.senials.meetmember.repository;
 
+import com.senials.meet.entity.Meet;
 import com.senials.meetmember.entity.MeetMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MeetMemberRepository extends JpaRepository<MeetMember, Integer> {
+
+    /* 모임 일정 참여멤버 조회 */
+    List<MeetMember> findAllByMeet(Meet meet);
 }

--- a/src/main/java/com/senials/meetmember/service/MeetMemberService.java
+++ b/src/main/java/com/senials/meetmember/service/MeetMemberService.java
@@ -1,0 +1,52 @@
+package com.senials.meetmember.service;
+
+import com.senials.common.mapper.UserMapper;
+import com.senials.meet.entity.Meet;
+import com.senials.meet.repository.MeetRepository;
+import com.senials.meetmember.entity.MeetMember;
+import com.senials.meetmember.repository.MeetMemberRepository;
+import com.senials.user.dto.UserDTOForPublic;
+import com.senials.user.entity.User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MeetMemberService {
+
+    private final UserMapper userMapper;
+    private final MeetRepository meetRepository;
+    private final MeetMemberRepository meetMemberRepository;
+
+    public MeetMemberService(
+            UserMapper userMapper,
+            MeetRepository meetRepository
+            , MeetMemberRepository meetMemberRepository
+    ) {
+        this.userMapper = userMapper;
+        this.meetRepository = meetRepository;
+        this.meetMemberRepository = meetMemberRepository;
+    }
+
+    /* 모임 일정 참여멤버 조회 */
+    public List<UserDTOForPublic> getMeetMembersByMeetNumber(int meetNumber) {
+
+        Meet meet = meetRepository.findById(meetNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+        /* 일정 참여 멤버 리스트 도출 */
+        List<MeetMember> meetMemberList = meetMemberRepository.findAllByMeet(meet);
+
+        /* 멤버 리스트 -> 유저 정보 도출 */
+        List<User> userList = meetMemberList.stream()
+                .map(meetMember -> meetMember.getPartyMember().getUser())
+                .toList();
+
+        /* DTO로 변환 */
+        List<UserDTOForPublic> userDTOForPublicList = userList.stream()
+                .map(userMapper::toUserDTOForPublic)
+                .toList();
+
+        return userDTOForPublicList;
+    }
+}

--- a/src/main/java/com/senials/user/dto/UserDTOForPublic.java
+++ b/src/main/java/com/senials/user/dto/UserDTOForPublic.java
@@ -1,0 +1,47 @@
+package com.senials.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class UserDTOForPublic {
+
+    private int userNumber;
+
+    private String userName;
+
+    private LocalDate userBirth;
+
+    private int userGender;
+
+    private int userStatus;
+
+    private String userNickname;
+
+    private String userDetail;
+
+    private String userProfileImg;
+
+    private LocalDate userSignupDate;
+
+    /* AllArgsConstructor */
+    public UserDTOForPublic(int userNumber, String userName, LocalDate userBirth, int userGender, int userStatus, String userNickname, String userDetail, String userProfileImg, LocalDate userSignupDate) {
+        this.userNumber = userNumber;
+        this.userName = userName;
+        this.userBirth = userBirth;
+        this.userGender = userGender;
+        this.userStatus = userStatus;
+        this.userNickname = userNickname;
+        this.userDetail = userDetail;
+        this.userProfileImg = userProfileImg;
+        this.userSignupDate = userSignupDate;
+    }
+}
+


### PR DESCRIPTION
## 이슈
- Resolve #11 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/67bec1c1-940e-4369-908a-4a162f4f25a4)



## 📝작업 내용
- 특정 모임에 참여한 멤버들을 조회하는 REST API 구현


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
- ### MeetMemberService
![image](https://github.com/user-attachments/assets/4f2deebb-900a-4430-890a-4d08587f38e7)
![image](https://github.com/user-attachments/assets/a179856c-d3eb-42be-8d18-efd252f80bae)


## 🚨수정 필요 내용
- 같이 참여중인 멤버만 접근할 수 있도록 제한
