### PR TITLE
[feature/backend-29/suggesthobby/get-suggesthobby-detail] 맞춤형 취미 추천 결과 조회 Rest api 기능 구현

### DIFF
--- a/http/hobbyTest.http
+++ b/http/hobbyTest.http
@@ -38,3 +38,6 @@ Content-Type: application/json;charset=UTF-8
   "hobbyReviewLevel": 1,
   "hobbyReviewWriteDate": "2024-12-02"
 }
+
+###맞춤형 취미 추천 결과 조회
+GET http://localhost:8081/suggest-hobby-result?hobbyAbility=3&hobbyBudget=2&hobbyLevel=2&hobbyTendency=1

--- a/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
+++ b/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
@@ -8,10 +8,7 @@ import com.senials.hobbyreview.dto.HobbyReviewDTO;
 import com.senials.hobbyreview.service.HobbyReviewService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -75,6 +72,23 @@ public class HobbyController {
         responseMap.put("hobby", hobbyDTOList);
 
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));
+    }
+
+    //맞춤형 취미 추천 결과 조회
+    @GetMapping("/suggest-hobby-result")
+    public ResponseEntity<ResponseMessage> getSuggestHobby(@RequestParam int hobbyAbility,
+                                                           @RequestParam int hobbyBudget,
+                                                           @RequestParam int hobbyLevel,
+                                                           @RequestParam int hobbyTendency) {
+
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+
+        HobbyDTO hobbyDTO = hobbyService.suggestHobby(hobbyAbility, hobbyBudget,hobbyTendency, hobbyLevel);
+
+        Map<String, Object> responseMap = new HashMap<String, Object>();
+        responseMap.put("hobby", hobbyDTO);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(201, "생성 성공", responseMap));
     }
 
 }

--- a/src/main/java/com/senials/hobbyboard/repository/HobbyRepository.java
+++ b/src/main/java/com/senials/hobbyboard/repository/HobbyRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface HobbyRepository extends JpaRepository<Hobby, Integer> {
     List<Hobby> findByCategoryNumber(int categoryNumber);
+
+    List<Hobby> findByHobbyAbility(int hobbyAbility);
 }

--- a/src/main/java/com/senials/hobbyboard/service/HobbyService.java
+++ b/src/main/java/com/senials/hobbyboard/service/HobbyService.java
@@ -11,6 +11,8 @@ import com.senials.hobbyreview.repository.HobbyReviewRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 @Service
 public class HobbyService {
@@ -20,35 +22,71 @@ public class HobbyService {
     private final HobbyReviewMapper hobbyReviewMapper;
     private final HobbyReviewRepository hobbyReviewRepository;
 
-    public HobbyService(HobbyRepository hobbyRepository, HobbyMapper hobbyMapper, HobbyReviewRepository hobbyReviewRepository, HobbyReviewMapper hobbyReviewMapper){
-        this.hobbyRepository=hobbyRepository;
-        this.hobbyMapper=hobbyMapper;
-        this.hobbyReviewRepository=hobbyReviewRepository;
-        this.hobbyReviewMapper=hobbyReviewMapper;
+    public HobbyService(HobbyRepository hobbyRepository, HobbyMapper hobbyMapper, HobbyReviewRepository hobbyReviewRepository, HobbyReviewMapper hobbyReviewMapper) {
+        this.hobbyRepository = hobbyRepository;
+        this.hobbyMapper = hobbyMapper;
+        this.hobbyReviewRepository = hobbyReviewRepository;
+        this.hobbyReviewMapper = hobbyReviewMapper;
     }
-    //전체 hobby 불러오기
-    public List<HobbyDTO>findAll(){
-        List<Hobby> hobbyList=hobbyRepository.findAll();
 
-        List<HobbyDTO> hobbyDTOList=hobbyList.stream().map(hobby -> hobbyMapper.toHobbyDTO(hobby)).toList();
+    //전체 hobby 불러오기
+    public List<HobbyDTO> findAll() {
+        List<Hobby> hobbyList = hobbyRepository.findAll();
+
+        List<HobbyDTO> hobbyDTOList = hobbyList.stream().map(hobby -> hobbyMapper.toHobbyDTO(hobby)).toList();
 
         return hobbyDTOList;
     }
 
     //특정 hobby hobbyNumber로 불러오기
-    public HobbyDTO findById(int hobbyNumber){
-        Hobby hobby=hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미가 존재하지 않습니다: " + hobbyNumber));
-        HobbyDTO hobbyDTO=hobbyMapper.toHobbyDTO(hobby);
+    public HobbyDTO findById(int hobbyNumber) {
+        Hobby hobby = hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미가 존재하지 않습니다: " + hobbyNumber));
+        HobbyDTO hobbyDTO = hobbyMapper.toHobbyDTO(hobby);
 
         return hobbyDTO;
     }
 
     //특정 hobby들 categoryNumber로 불러오기
-    public List<HobbyDTO>findByCategory(int categoryNumber){
-        List<Hobby> hobbyList=hobbyRepository.findByCategoryNumber(categoryNumber);
+    public List<HobbyDTO> findByCategory(int categoryNumber) {
+        List<Hobby> hobbyList = hobbyRepository.findByCategoryNumber(categoryNumber);
 
-        List<HobbyDTO> hobbyDTOList=hobbyList.stream().map(hobby -> hobbyMapper.toHobbyDTO(hobby)).toList();
+        List<HobbyDTO> hobbyDTOList = hobbyList.stream().map(hobby -> hobbyMapper.toHobbyDTO(hobby)).toList();
 
         return hobbyDTOList;
     }
+
+    //4가지 요소를 우선순위로 둬서 최종적으로 하나의 hobby를 조회
+    public HobbyDTO suggestHobby(int hobbyAbility, int hobbyBudget, int hobbyLevel, int hobbyTendency) {
+        List<Hobby> hobbyList = null;
+        List<Hobby> tempList = hobbyRepository.findByHobbyAbility(hobbyAbility);
+        if (!tempList.isEmpty()) {
+            hobbyList = tempList;
+            tempList = tempList.stream()
+                    .filter(hobby -> hobby.getHobbyBudget() == hobbyBudget)
+                    .collect(Collectors.toList());
+            if (!tempList.isEmpty()) {
+                hobbyList = tempList;
+                tempList = tempList.stream()
+                        .filter(hobby -> hobby.getHobbyBudget() == hobbyTendency)
+                        .collect(Collectors.toList());
+                if (!tempList.isEmpty()) {
+                    hobbyList = tempList;
+                    tempList = tempList.stream()
+                            .filter(hobby -> hobby.getHobbyBudget() == hobbyLevel)
+                            .collect(Collectors.toList());
+                    if (!tempList.isEmpty()) {
+                        hobbyList = tempList;
+                    }
+                }
+            }
+        }
+        List<HobbyDTO> hobbyDTOList = hobbyList.stream().map(hobby -> hobbyMapper.toHobbyDTO(hobby)).toList();
+
+        Random random = new Random();
+        int randomIndex = random.nextInt(hobbyDTOList.size());
+        HobbyDTO hobbyDTO = hobbyDTOList.get(randomIndex);
+
+        return hobbyDTO;
+    }
+
 }


### PR DESCRIPTION
## 이슈
- #29 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/57d5b210-6ef0-4642-b65e-c8288e796662)


## 📝작업 내용
- 맞춤형 취미 추천 결과 조회 Rest api 기능 구현
  - repository HpbbyRepository findByHobbyAbility() Jpa 쿼리 메소드 추가, 취미 1차 필터 
  - service HobbyService suggestHobby() 메소드 추가, 4가지 요소를 우선순위로 둬서 최종적으로 하나의 hobby를 조회
  - controller HobbyController getSuggestHobby() 메소드 추가 및 연동, 맞춤형 취미 추천 결과 조회


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/5960a9dc-68c3-4e4e-a6d0-8732233c1dd1)
![image](https://github.com/user-attachments/assets/3e070152-6934-40d7-a6f0-ecdc70895a2d)
![image](https://github.com/user-attachments/assets/9bec4aed-ebd2-4b05-9e69-cb0da34e4a27)
![image](https://github.com/user-attachments/assets/ec51a059-9ea8-4146-bfd4-28b0540a0265)






## 🚨수정 필요 내용
- 
