### PR TITLE
[feature/backend-15/partyreviews/register-partyreview] 모임 후기 작성 REST API 구현

### DIFF
--- a/http/partyreview.http
+++ b/http/partyreview.http
@@ -4,3 +4,12 @@ GET https://examples.http-client.intellij.net/get
 
 ### 모임 후기 전체 조회
 GET http://localhost:8080/partyboards/1/partyreviews
+
+### 모임 후기 작성
+POST http://localhost:8080/partyboards/2/partyreviews
+Content-Type: application/json;application/json;charset=UTF-8
+
+{
+  "partyReviewRate" : 3,
+  "partyReviewDetail" : "testPartyReviewDetail"
+}

--- a/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
+++ b/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
@@ -6,9 +6,7 @@ import com.senials.partyreview.service.PartyReviewService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -39,4 +37,21 @@ public class PartyReviewController {
         headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 전체 조회 성공", responseMap));
     }
+
+    /* 모임 후기 작성 */
+    @PostMapping("/partyboards/{partyBoardNumber}/partyreviews")
+    public ResponseEntity<ResponseMessage> registerPartyReview (
+            @PathVariable Integer partyBoardNumber
+            , @RequestBody PartyReviewDTO partyReviewDTO
+    ) {
+        // 유저 번호 임의 지정
+        int userNumber = 4;
+
+        partyReviewService.registerPartyReview(userNumber, partyBoardNumber, partyReviewDTO);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 작성 성공", null));
+    }
+
 }

--- a/src/main/java/com/senials/partyreview/entity/PartyReview.java
+++ b/src/main/java/com/senials/partyreview/entity/PartyReview.java
@@ -54,7 +54,7 @@ public class PartyReview {
     }
 
 
-    /* 모임 후기 작성 시 작성자, 모임, 작성일자 세팅 */
+    /* 모임후기 작성 시 작성자, 모임, 작성일자 세팅 */
     public void initializeUser(User user) {
         this.user = user;
     }

--- a/src/main/java/com/senials/partyreview/service/PartyReviewService.java
+++ b/src/main/java/com/senials/partyreview/service/PartyReviewService.java
@@ -7,9 +7,12 @@ import com.senials.partyboard.repository.PartyBoardRepository;
 import com.senials.partyreview.dto.PartyReviewDTO;
 import com.senials.partyreview.entity.PartyReview;
 import com.senials.partyreview.repository.PartyReviewRepository;
+import com.senials.user.entity.User;
 import com.senials.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -53,4 +56,27 @@ public class PartyReviewService {
         return partyReviewDTOList;
     }
 
+    /* 모임 후기 작성 */
+    @Transactional
+    public void registerPartyReview (
+            int userNumber
+            , int partyBoardNumber
+            , PartyReviewDTO partyReviewDTO
+    ) {
+
+        User user = userRepository.findById(userNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+        PartyBoard partyBoard = partyBoardRepository.findById(partyBoardNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+
+        PartyReview partyReview = partyReviewMapper.toPartyReview(partyReviewDTO);
+        partyReview.initializeUser(user);
+        partyReview.initializePartyBoard(partyBoard);
+        partyReview.initializePartyReviewWriteDate(LocalDateTime.now());
+
+
+        partyReviewRepository.save(partyReview);
+    }
 }


### PR DESCRIPTION
## 이슈
- Resolve #15 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/993ee1b8-c5f8-49da-b8e0-6c82588a3418)


## 📝작업 내용
- 모임 후기 작성 REST API 구현함


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/9a804b03-0199-47e5-a885-e7a917eaf629)
![image](https://github.com/user-attachments/assets/03cfeaf3-06ab-4d0f-ab35-eea990912fe7)
![image](https://github.com/user-attachments/assets/7afd0058-b1a7-457d-9537-f2c4edb411e5)


## 🚨수정 필요 내용
- 모임 후기가 모임과 유저 엔티티 간에 연결 되어있는 상태인데 구조를 바꿔야 할 것으로 보임
  - 모임멤버와 모임을 연결하도록
