### PR TITLE
[feature/backend-16/partyreviews/update-partyreview] 모임 후기 수정 REST API 구현

### DIFF
--- a/http/partyreview.http
+++ b/http/partyreview.http
@@ -13,3 +13,12 @@ Content-Type: application/json;application/json;charset=UTF-8
   "partyReviewRate" : 3,
   "partyReviewDetail" : "testPartyReviewDetail"
 }
+
+### 모임 후기 수정
+PUT http://localhost:8080/partyboards/1/partyreviews/14
+Content-Type: application/json;application/json;charset=UTF-8
+
+{
+  "partyReviewRate" : 4,
+  "partyReviewDetail" : "testPartyReviewDetailModified"
+}

--- a/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
+++ b/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
@@ -54,4 +54,19 @@ public class PartyReviewController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 작성 성공", null));
     }
 
+
+    /* 모임 후기 수정 */
+    @PutMapping("/partyboards/{partyBoardNumber}/partyreviews/{partyReviewNumber}")
+    public ResponseEntity<ResponseMessage> modifyPartyReview (
+            @PathVariable Integer partyReviewNumber
+            , @RequestBody PartyReviewDTO partyReviewDTO
+    ) {
+
+        partyReviewService.modifyPartyReview(partyReviewNumber, partyReviewDTO);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 수정 성공", null));
+    }
+
 }

--- a/src/main/java/com/senials/partyreview/entity/PartyReview.java
+++ b/src/main/java/com/senials/partyreview/entity/PartyReview.java
@@ -65,4 +65,13 @@ public class PartyReview {
         this.partyReviewWriteDate = partyReviewWriteDate;
     }
 
+
+    /* 모임 후기 수정용 */
+    public void updatePartyReviewRate(int partyReviewRate) {
+        this.partyReviewRate = partyReviewRate;
+    }
+    public void updatePartyReviewDetail(String partyReviewDetail) {
+        this.partyReviewDetail = partyReviewDetail;
+    }
+
 }

--- a/src/main/java/com/senials/partyreview/service/PartyReviewService.java
+++ b/src/main/java/com/senials/partyreview/service/PartyReviewService.java
@@ -79,4 +79,17 @@ public class PartyReviewService {
 
         partyReviewRepository.save(partyReview);
     }
+
+    /* 모임 후기 수정 */
+    @Transactional
+    public void modifyPartyReview(
+            int partyReviewNumber
+            , PartyReviewDTO partyReviewDTO
+    ) {
+        PartyReview partyReview = partyReviewRepository.findById(partyReviewNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+        partyReview.updatePartyReviewRate(partyReviewDTO.getPartyReviewRate());
+        partyReview.updatePartyReviewDetail(partyReviewDTO.getPartyReviewDetail());
+    }
 }


### PR DESCRIPTION
## 이슈
- Resolve #16 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/ec66025b-6786-4897-876f-e280266f3d8f)


## 📝작업 내용
- 모임 후기 수정 REST API를 구현함


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
- ### PartyReviewService
![image](https://github.com/user-attachments/assets/bfcb45d6-7976-40a8-9f3b-1f719f785048)
- ### 이전 데이터
![image](https://github.com/user-attachments/assets/6476fd99-6b70-4c67-a0f8-8368a78a39ce)
- ### API 호출
![image](https://github.com/user-attachments/assets/7f54105f-78a5-4fdb-9677-d5acc62dd9dc)
- ### 결과
![image](https://github.com/user-attachments/assets/855d15e4-332d-4a5e-881b-7c4816659860)


## 🚨수정 필요 내용
- 로그인 세션 유저와 작성자 비교 필요
