### PR TITLE
[feature/backend-17/partyreviews/delete-partyreview] 모임 후기 삭제 REST API 구현

### DIFF
--- a/http/partyreview.http
+++ b/http/partyreview.http
@@ -22,3 +22,6 @@ Content-Type: application/json;application/json;charset=UTF-8
   "partyReviewRate" : 4,
   "partyReviewDetail" : "testPartyReviewDetailModified"
 }
+
+### 모임 후기 삭제
+DELETE http://localhost:8080/partyboards/1/partyreviews/13

--- a/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
+++ b/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
@@ -69,4 +69,17 @@ public class PartyReviewController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 수정 성공", null));
     }
 
+    /* 모임 후기 삭제 */
+    @DeleteMapping("/partyboards/{partyBoardNumber}/partyreviews/{partyReviewNumber}")
+    public ResponseEntity<ResponseMessage> removePartyReview (
+            @PathVariable Integer partyReviewNumber
+    ) {
+
+        partyReviewService.removePartyReview(partyReviewNumber);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 삭제 성공", null));
+    }
+
 }

--- a/src/main/java/com/senials/partyreview/service/PartyReviewService.java
+++ b/src/main/java/com/senials/partyreview/service/PartyReviewService.java
@@ -92,4 +92,12 @@ public class PartyReviewService {
         partyReview.updatePartyReviewRate(partyReviewDTO.getPartyReviewRate());
         partyReview.updatePartyReviewDetail(partyReviewDTO.getPartyReviewDetail());
     }
+
+    /* 모임 후기 삭제 */
+    @Transactional
+    public void removePartyReview (int partyReviewNumber) {
+
+        partyReviewRepository.deleteById(partyReviewNumber);
+
+    }
 }


### PR DESCRIPTION
## 이슈
- Resolve #17


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/8c2f5917-4d42-40fc-9948-94ca83b44841)


## 📝작업 내용
- 모임 후기 삭제 REST API를 구현함


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)

### PartyReviewService
![image](https://github.com/user-attachments/assets/77cf6518-a955-4d8b-b0e7-365391d02106)
### 변경전 데이터
![image](https://github.com/user-attachments/assets/d6fc3b88-5661-4579-8e56-a726dc5ec0fc)
### API 호출
![image](https://github.com/user-attachments/assets/62ef2854-3ad1-4d7e-a4bc-7826ec617e1d)
### 결과
![image](https://github.com/user-attachments/assets/8683a066-321c-4e3a-8865-6fcf6bd9e464)


## 🚨수정 필요 내용
- 로그인 세션 유저 == 작성자 일치여부 구현 예정
