### PR TITLE
[feature/backend-18/partymembers/get-all-partymembers] 모임 멤버 전체 조회 REST API 구현

### DIFF
--- a/http/partymember.http
+++ b/http/partymember.http
@@ -1,0 +1,7 @@
+### GET request to example server
+GET https://examples.http-client.intellij.net/get
+    ?generated-in=IntelliJ IDEA
+
+
+### 모임 멤버 전체 조회
+GET http://localhost:8080/partyboards/3/partymembers

--- a/http/partyreview.http
+++ b/http/partyreview.http
@@ -22,3 +22,6 @@ Content-Type: application/json;application/json;charset=UTF-8
   "partyReviewRate" : 4,
   "partyReviewDetail" : "testPartyReviewDetailModified"
 }
+
+### 모임 후기 삭제
+DELETE http://localhost:8080/partyboards/1/partyreviews/13

--- a/src/main/java/com/senials/partyboard/controller/PartyBoardController.java
+++ b/src/main/java/com/senials/partyboard/controller/PartyBoardController.java
@@ -5,6 +5,7 @@ import com.senials.partyboard.dto.PartyBoardDTOForDetail;
 import com.senials.partyboard.dto.PartyBoardDTOForModify;
 import com.senials.partyboard.dto.PartyBoardDTOForWrite;
 import com.senials.partyboard.service.PartyBoardService;
+import com.senials.user.dto.UserDTOForPublic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;

--- a/src/main/java/com/senials/partyboard/service/PartyBoardService.java
+++ b/src/main/java/com/senials/partyboard/service/PartyBoardService.java
@@ -13,6 +13,9 @@ import com.senials.partyboard.entity.PartyBoard;
 import com.senials.partyboard.repository.PartyBoardRepository;
 import com.senials.partyboard.repository.PartyBoardSpecification;
 import com.senials.partyboardimage.entity.PartyBoardImage;
+import com.senials.partymember.entity.PartyMember;
+import com.senials.partymember.repository.PartyMemberRepository;
+import com.senials.user.dto.UserDTOForPublic;
 import com.senials.user.entity.User;
 import com.senials.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +54,7 @@ public class PartyBoardService {
             , PartyBoardRepository partyBoardRepository
             , UserRepository userRepository
             , HobbyRepository hobbyRepository,
-            FavoritesRepository favoritesRepository)
+            FavoritesRepository favoritesRepository, PartyMemberRepository partyMemberRepository)
     {
         this.partyBoardMapper = partyBoardMapperImpl;
         this.partyBoardRepository = partyBoardRepository;

--- a/src/main/java/com/senials/partymember/controller/PartyMemberController.java
+++ b/src/main/java/com/senials/partymember/controller/PartyMemberController.java
@@ -1,0 +1,45 @@
+package com.senials.partymember.controller;
+
+import com.senials.common.ResponseMessage;
+import com.senials.partymember.service.PartyMemberService;
+import com.senials.user.dto.UserDTOForPublic;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+public class PartyMemberController {
+
+    private final PartyMemberService partyMemberService;
+
+
+    public PartyMemberController(
+            PartyMemberService partyMemberService
+    ) {
+        this.partyMemberService = partyMemberService;
+    }
+
+
+    /* 모임 멤버 전체 조회 */
+    @GetMapping("/partyboards/{partyBoardNumber}/partymembers")
+    public ResponseEntity<ResponseMessage> getPartyMembers (
+            @PathVariable Integer partyBoardNumber
+    ) {
+        List<UserDTOForPublic> userDTOForPublicList = partyMemberService.getPartyMembers(partyBoardNumber);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("partyMembers", userDTOForPublicList);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 멤버 전체 조회 성공", responseMap));
+    }
+}

--- a/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
+++ b/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
@@ -1,11 +1,15 @@
 package com.senials.partymember.repository;
 
+import com.senials.partyboard.entity.PartyBoard;
 import com.senials.partymember.entity.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Integer> {
+
     List<PartyMember> findByUser_UserNumber(int userNumber); // 사용자별 참여 데이터 조회
+
+    List<PartyMember> findAllByPartyBoard(PartyBoard partyBoard);
 
 }

--- a/src/main/java/com/senials/partymember/service/PartyMemberService.java
+++ b/src/main/java/com/senials/partymember/service/PartyMemberService.java
@@ -1,0 +1,47 @@
+package com.senials.partymember.service;
+
+import com.senials.common.mapper.UserMapper;
+import com.senials.common.mapper.UserMapperImpl;
+import com.senials.partyboard.entity.PartyBoard;
+import com.senials.partyboard.repository.PartyBoardRepository;
+import com.senials.partymember.entity.PartyMember;
+import com.senials.partymember.repository.PartyMemberRepository;
+import com.senials.user.dto.UserDTOForPublic;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PartyMemberService {
+
+    private final UserMapper userMapper;
+    private final PartyBoardRepository partyBoardRepository;
+    private final PartyMemberRepository partyMemberRepository;
+
+    public PartyMemberService(
+            UserMapperImpl userMapperImpl
+            , PartyBoardRepository partyBoardRepository
+            , PartyMemberRepository partyMemberRepository
+    ) {
+        this.userMapper = userMapperImpl;
+        this.partyBoardRepository = partyBoardRepository;
+        this.partyMemberRepository = partyMemberRepository;
+    }
+
+    /* 모임 멤버 전체 조회 */
+    public List<UserDTOForPublic> getPartyMembers (int partyBoardNumber) {
+
+        PartyBoard partyBoard = partyBoardRepository.findById(partyBoardNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+        /* 모임 번호에 해당하는 멤버 리스트 도출 */
+        List<PartyMember> partyMemberList = partyMemberRepository.findAllByPartyBoard(partyBoard);
+
+        /* 멤버 리스트를 통해 유저 정보 도출 */
+        List<UserDTOForPublic> userDTOForPublicList = partyMemberList.stream()
+                .map(partyMember -> userMapper.toUserDTOForPublic(partyMember.getUser()))
+                .toList();
+
+        return userDTOForPublicList;
+    }
+}

--- a/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
+++ b/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
@@ -69,4 +69,17 @@ public class PartyReviewController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 수정 성공", null));
     }
 
+    /* 모임 후기 삭제 */
+    @DeleteMapping("/partyboards/{partyBoardNumber}/partyreviews/{partyReviewNumber}")
+    public ResponseEntity<ResponseMessage> removePartyReview (
+            @PathVariable Integer partyReviewNumber
+    ) {
+
+        partyReviewService.removePartyReview(partyReviewNumber);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 삭제 성공", null));
+    }
+
 }

--- a/src/main/java/com/senials/partyreview/service/PartyReviewService.java
+++ b/src/main/java/com/senials/partyreview/service/PartyReviewService.java
@@ -92,4 +92,12 @@ public class PartyReviewService {
         partyReview.updatePartyReviewRate(partyReviewDTO.getPartyReviewRate());
         partyReview.updatePartyReviewDetail(partyReviewDTO.getPartyReviewDetail());
     }
+
+    /* 모임 후기 삭제 */
+    @Transactional
+    public void removePartyReview (int partyReviewNumber) {
+
+        partyReviewRepository.deleteById(partyReviewNumber);
+
+    }
 }


### PR DESCRIPTION
## 이슈
- Resolve #18 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/3afd24db-6d5c-4ede-915e-451b64e4b2e3)


## 📝작업 내용
- 모임 멤버 전체 조회 REST API를 구현한다.


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
- ### PartyMemberService
![image](https://github.com/user-attachments/assets/ac1dc7bf-26e4-4689-9161-233769822e12)
- ### 호출 결과
![image](https://github.com/user-attachments/assets/196fc3ce-3701-493a-b087-e9917a42e62a)


## 🚨수정 필요 내용
- 
