### PR TITLE
[feature/backend-20/partymembers/leave-party] 모임 탈퇴 REST API 구현

### DIFF
--- a/http/partymember.http
+++ b/http/partymember.http
@@ -9,3 +9,6 @@ GET http://localhost:8080/partyboards/3/partymembers
 
 ### 모임 참가
 POST http://localhost:8080/partyboards/5/partymembers
+
+### 모임 탈퇴
+DELETE http://localhost:8080/partyboards/5/partymembers

--- a/http/partymember.http
+++ b/http/partymember.http
@@ -5,3 +5,7 @@ GET https://examples.http-client.intellij.net/get
 
 ### 모임 멤버 전체 조회
 GET http://localhost:8080/partyboards/3/partymembers
+
+
+### 모임 참가
+POST http://localhost:8080/partyboards/5/partymembers

--- a/http/partymember.http
+++ b/http/partymember.http
@@ -1,0 +1,7 @@
+### GET request to example server
+GET https://examples.http-client.intellij.net/get
+    ?generated-in=IntelliJ IDEA
+
+
+### 모임 멤버 전체 조회
+GET http://localhost:8080/partyboards/3/partymembers

--- a/http/partyreview.http
+++ b/http/partyreview.http
@@ -22,3 +22,6 @@ Content-Type: application/json;application/json;charset=UTF-8
   "partyReviewRate" : 4,
   "partyReviewDetail" : "testPartyReviewDetailModified"
 }
+
+### 모임 후기 삭제
+DELETE http://localhost:8080/partyboards/1/partyreviews/13

--- a/src/main/java/com/senials/partyboard/controller/PartyBoardController.java
+++ b/src/main/java/com/senials/partyboard/controller/PartyBoardController.java
@@ -5,6 +5,7 @@ import com.senials.partyboard.dto.PartyBoardDTOForDetail;
 import com.senials.partyboard.dto.PartyBoardDTOForModify;
 import com.senials.partyboard.dto.PartyBoardDTOForWrite;
 import com.senials.partyboard.service.PartyBoardService;
+import com.senials.user.dto.UserDTOForPublic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;

--- a/src/main/java/com/senials/partyboard/entity/PartyBoard.java
+++ b/src/main/java/com/senials/partyboard/entity/PartyBoard.java
@@ -119,4 +119,9 @@ public class PartyBoard {
         this.partyBoardStatus = partyBoardStatus;
     }
 
+
+    /* 모임 가입 */
+    public void registerPartyMember(PartyMember partyMember) {
+        this.partyMembers.add(partyMember);
+    }
 }

--- a/src/main/java/com/senials/partyboard/service/PartyBoardService.java
+++ b/src/main/java/com/senials/partyboard/service/PartyBoardService.java
@@ -13,6 +13,9 @@ import com.senials.partyboard.entity.PartyBoard;
 import com.senials.partyboard.repository.PartyBoardRepository;
 import com.senials.partyboard.repository.PartyBoardSpecification;
 import com.senials.partyboardimage.entity.PartyBoardImage;
+import com.senials.partymember.entity.PartyMember;
+import com.senials.partymember.repository.PartyMemberRepository;
+import com.senials.user.dto.UserDTOForPublic;
 import com.senials.user.entity.User;
 import com.senials.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +54,7 @@ public class PartyBoardService {
             , PartyBoardRepository partyBoardRepository
             , UserRepository userRepository
             , HobbyRepository hobbyRepository,
-            FavoritesRepository favoritesRepository)
+            FavoritesRepository favoritesRepository, PartyMemberRepository partyMemberRepository)
     {
         this.partyBoardMapper = partyBoardMapperImpl;
         this.partyBoardRepository = partyBoardRepository;

--- a/src/main/java/com/senials/partymember/controller/PartyMemberController.java
+++ b/src/main/java/com/senials/partymember/controller/PartyMemberController.java
@@ -6,10 +6,7 @@ import com.senials.user.dto.UserDTOForPublic;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -57,5 +54,19 @@ public class PartyMemberController {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 가입 성공", null));
+    }
+
+    /* 모임 탈퇴 */
+    @DeleteMapping("/partyboards/{partyBoardNumber}/partymembers")
+    public ResponseEntity<ResponseMessage> unregisterPartyMember (
+            @PathVariable Integer partyBoardNumber
+    ) {
+        /* 세션 유저 */
+        int userNumber = 2;
+        partyMemberService.unregisterPartyMember(userNumber, partyBoardNumber);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 탈퇴 성공", null));
     }
 }

--- a/src/main/java/com/senials/partymember/controller/PartyMemberController.java
+++ b/src/main/java/com/senials/partymember/controller/PartyMemberController.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.nio.charset.StandardCharsets;
@@ -41,5 +42,20 @@ public class PartyMemberController {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 멤버 전체 조회 성공", responseMap));
+    }
+
+    /* 모임 참가 */
+    @PostMapping("/partyboards/{partyBoardNumber}/partymembers")
+    public ResponseEntity<ResponseMessage> registerPartyMember (
+            @PathVariable Integer partyBoardNumber
+    ) {
+        // 유저 번호 임의 지정
+        int userNumber = 2;
+
+        partyMemberService.registerPartyMember(userNumber, partyBoardNumber);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 가입 성공", null));
     }
 }

--- a/src/main/java/com/senials/partymember/controller/PartyMemberController.java
+++ b/src/main/java/com/senials/partymember/controller/PartyMemberController.java
@@ -1,0 +1,45 @@
+package com.senials.partymember.controller;
+
+import com.senials.common.ResponseMessage;
+import com.senials.partymember.service.PartyMemberService;
+import com.senials.user.dto.UserDTOForPublic;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+public class PartyMemberController {
+
+    private final PartyMemberService partyMemberService;
+
+
+    public PartyMemberController(
+            PartyMemberService partyMemberService
+    ) {
+        this.partyMemberService = partyMemberService;
+    }
+
+
+    /* 모임 멤버 전체 조회 */
+    @GetMapping("/partyboards/{partyBoardNumber}/partymembers")
+    public ResponseEntity<ResponseMessage> getPartyMembers (
+            @PathVariable Integer partyBoardNumber
+    ) {
+        List<UserDTOForPublic> userDTOForPublicList = partyMemberService.getPartyMembers(partyBoardNumber);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("partyMembers", userDTOForPublicList);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 멤버 전체 조회 성공", responseMap));
+    }
+}

--- a/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
+++ b/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
@@ -2,6 +2,7 @@ package com.senials.partymember.repository;
 
 import com.senials.partyboard.entity.PartyBoard;
 import com.senials.partymember.entity.PartyMember;
+import com.senials.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,5 +12,7 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember, Intege
     List<PartyMember> findByUser_UserNumber(int userNumber); // 사용자별 참여 데이터 조회
 
     List<PartyMember> findAllByPartyBoard(PartyBoard partyBoard);
+
+    PartyMember findByPartyBoardAndUser(PartyBoard partyBoard, User user);
 
 }

--- a/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
+++ b/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
@@ -1,11 +1,15 @@
 package com.senials.partymember.repository;
 
+import com.senials.partyboard.entity.PartyBoard;
 import com.senials.partymember.entity.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Integer> {
+
     List<PartyMember> findByUser_UserNumber(int userNumber); // 사용자별 참여 데이터 조회
+
+    List<PartyMember> findAllByPartyBoard(PartyBoard partyBoard);
 
 }

--- a/src/main/java/com/senials/partymember/service/PartyMemberService.java
+++ b/src/main/java/com/senials/partymember/service/PartyMemberService.java
@@ -7,7 +7,10 @@ import com.senials.partyboard.repository.PartyBoardRepository;
 import com.senials.partymember.entity.PartyMember;
 import com.senials.partymember.repository.PartyMemberRepository;
 import com.senials.user.dto.UserDTOForPublic;
+import com.senials.user.entity.User;
+import com.senials.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -17,15 +20,17 @@ public class PartyMemberService {
     private final UserMapper userMapper;
     private final PartyBoardRepository partyBoardRepository;
     private final PartyMemberRepository partyMemberRepository;
+    private final UserRepository userRepository;
 
     public PartyMemberService(
             UserMapperImpl userMapperImpl
             , PartyBoardRepository partyBoardRepository
-            , PartyMemberRepository partyMemberRepository
-    ) {
+            , PartyMemberRepository partyMemberRepository,
+            UserRepository userRepository) {
         this.userMapper = userMapperImpl;
         this.partyBoardRepository = partyBoardRepository;
         this.partyMemberRepository = partyMemberRepository;
+        this.userRepository = userRepository;
     }
 
     /* 모임 멤버 전체 조회 */
@@ -43,5 +48,21 @@ public class PartyMemberService {
                 .toList();
 
         return userDTOForPublicList;
+    }
+
+
+    /* 모임 참가 */
+    @Transactional
+    public void registerPartyMember (int userNumber, int partyBoardNumber) {
+        User user = userRepository.findById(userNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+        PartyBoard partyBoard = partyBoardRepository.findById(partyBoardNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+        PartyMember newMember = new PartyMember(0, partyBoard, user);
+
+        partyBoard.registerPartyMember(newMember);
+
     }
 }

--- a/src/main/java/com/senials/partymember/service/PartyMemberService.java
+++ b/src/main/java/com/senials/partymember/service/PartyMemberService.java
@@ -65,4 +65,23 @@ public class PartyMemberService {
         partyBoard.registerPartyMember(newMember);
 
     }
+
+
+    /* 모임 탈퇴 */
+    @Transactional
+    public void unregisterPartyMember (int userNumber, int partyBoardNumber) {
+
+        PartyBoard targetPartyBoard = partyBoardRepository.findById(partyBoardNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+        User targetUser = userRepository.findById(userNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+
+        PartyMember targetPartyMember = partyMemberRepository.findByPartyBoardAndUser(targetPartyBoard, targetUser);
+
+
+        partyMemberRepository.delete(targetPartyMember);
+
+    }
 }

--- a/src/main/java/com/senials/partymember/service/PartyMemberService.java
+++ b/src/main/java/com/senials/partymember/service/PartyMemberService.java
@@ -1,0 +1,47 @@
+package com.senials.partymember.service;
+
+import com.senials.common.mapper.UserMapper;
+import com.senials.common.mapper.UserMapperImpl;
+import com.senials.partyboard.entity.PartyBoard;
+import com.senials.partyboard.repository.PartyBoardRepository;
+import com.senials.partymember.entity.PartyMember;
+import com.senials.partymember.repository.PartyMemberRepository;
+import com.senials.user.dto.UserDTOForPublic;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PartyMemberService {
+
+    private final UserMapper userMapper;
+    private final PartyBoardRepository partyBoardRepository;
+    private final PartyMemberRepository partyMemberRepository;
+
+    public PartyMemberService(
+            UserMapperImpl userMapperImpl
+            , PartyBoardRepository partyBoardRepository
+            , PartyMemberRepository partyMemberRepository
+    ) {
+        this.userMapper = userMapperImpl;
+        this.partyBoardRepository = partyBoardRepository;
+        this.partyMemberRepository = partyMemberRepository;
+    }
+
+    /* 모임 멤버 전체 조회 */
+    public List<UserDTOForPublic> getPartyMembers (int partyBoardNumber) {
+
+        PartyBoard partyBoard = partyBoardRepository.findById(partyBoardNumber)
+                .orElseThrow(IllegalArgumentException::new);
+
+        /* 모임 번호에 해당하는 멤버 리스트 도출 */
+        List<PartyMember> partyMemberList = partyMemberRepository.findAllByPartyBoard(partyBoard);
+
+        /* 멤버 리스트를 통해 유저 정보 도출 */
+        List<UserDTOForPublic> userDTOForPublicList = partyMemberList.stream()
+                .map(partyMember -> userMapper.toUserDTOForPublic(partyMember.getUser()))
+                .toList();
+
+        return userDTOForPublicList;
+    }
+}

--- a/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
+++ b/src/main/java/com/senials/partyreview/controller/PartyReviewController.java
@@ -69,4 +69,17 @@ public class PartyReviewController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 수정 성공", null));
     }
 
+    /* 모임 후기 삭제 */
+    @DeleteMapping("/partyboards/{partyBoardNumber}/partyreviews/{partyReviewNumber}")
+    public ResponseEntity<ResponseMessage> removePartyReview (
+            @PathVariable Integer partyReviewNumber
+    ) {
+
+        partyReviewService.removePartyReview(partyReviewNumber);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "모임 후기 삭제 성공", null));
+    }
+
 }

--- a/src/main/java/com/senials/partyreview/service/PartyReviewService.java
+++ b/src/main/java/com/senials/partyreview/service/PartyReviewService.java
@@ -92,4 +92,12 @@ public class PartyReviewService {
         partyReview.updatePartyReviewRate(partyReviewDTO.getPartyReviewRate());
         partyReview.updatePartyReviewDetail(partyReviewDTO.getPartyReviewDetail());
     }
+
+    /* 모임 후기 삭제 */
+    @Transactional
+    public void removePartyReview (int partyReviewNumber) {
+
+        partyReviewRepository.deleteById(partyReviewNumber);
+
+    }
 }


### PR DESCRIPTION
## 이슈
- Resolve #20 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/cfec1045-4a40-45d5-a565-bf072eb5adc0)


## 📝작업 내용
- 모임 탈퇴 REST API를 구현


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
- ### PartyMemberService
![image](https://github.com/user-attachments/assets/67d97c7b-08f2-4dee-9091-51848e9394b5)
- ### 이전 데이터
![image](https://github.com/user-attachments/assets/899587f3-1f59-4ea2-b682-0f3fcc1f9a41)
- ### REST API 호출 (2번 유저가 5번 모임 탈퇴)
![image](https://github.com/user-attachments/assets/945c1d08-52f9-4a61-9812-d16f91475f2a)
- ### 결과
![image](https://github.com/user-attachments/assets/fde45918-4414-48bf-9071-004f32fe12b4)

