### PR TITLE
[feature/backend-31/suggesthobby/get-suggesthobby-party] 맞춤형 취미 추천 관련 모임 조회 Rest api 기능 구현

### DIFF
--- a/http/hobbyTest.http
+++ b/http/hobbyTest.http
@@ -44,3 +44,6 @@ GET http://localhost:8081/suggest-hobby-result?hobbyAbility=3&hobbyBudget=2&hobb
 
 ###맞춤형 취미 추천 나의 취미 등록
 POST  http://localhost:8081/suggest-hobby-result?hobbyNumber=3
+
+###맞춤형 취미 추천 관련 모임 조회
+GET http://localhost:8081/partyboards/search/1

--- a/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
+++ b/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
@@ -7,6 +7,7 @@ import com.senials.hobbyboard.dto.HobbyDTO;
 import com.senials.hobbyboard.service.HobbyService;
 import com.senials.hobbyreview.dto.HobbyReviewDTO;
 import com.senials.hobbyreview.service.HobbyReviewService;
+import com.senials.partyboard.dto.PartyBoardDTOForDetail;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -108,4 +109,15 @@ public class HobbyController {
 
     }
 
+    @GetMapping("/partyboards/search/{hobbyNumber}")
+    public ResponseEntity<ResponseMessage> getPartyBoardByHobbyNumber(@PathVariable("hobbyNumber") int hobbyNumber) {
+
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+
+        List<PartyBoardDTOForDetail> partyBoardDTOList = hobbyService.getPartyBoardByHobbyNumber(hobbyNumber);
+
+        Map<String, Object> responseMap = new HashMap<String, Object>();
+        responseMap.put("party", partyBoardDTOList);
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(201, "생성 성공", responseMap));
+    }
 }

--- a/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
+++ b/src/main/java/com/senials/hobbyboard/controller/HobbyController.java
@@ -109,6 +109,7 @@ public class HobbyController {
 
     }
 
+    //맞춤형 취미 추천 관련 모임 조회
     @GetMapping("/partyboards/search/{hobbyNumber}")
     public ResponseEntity<ResponseMessage> getPartyBoardByHobbyNumber(@PathVariable("hobbyNumber") int hobbyNumber) {
 

--- a/src/main/java/com/senials/hobbyboard/service/HobbyService.java
+++ b/src/main/java/com/senials/hobbyboard/service/HobbyService.java
@@ -1,11 +1,15 @@
 package com.senials.hobbyboard.service;
 
 import com.senials.common.mapper.HobbyMapper;
+import com.senials.common.mapper.PartyBoardMapper;
 import com.senials.favorites.entity.Favorites;
 import com.senials.favorites.repository.FavoritesRepository;
 import com.senials.hobbyboard.dto.HobbyDTO;
 import com.senials.hobbyboard.entity.Hobby;
 import com.senials.hobbyboard.repository.HobbyRepository;
+import com.senials.partyboard.dto.PartyBoardDTOForDetail;
+import com.senials.partyboard.entity.PartyBoard;
+import com.senials.partyboard.repository.PartyBoardRepository;
 import com.senials.user.entity.User;
 import com.senials.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -22,12 +26,21 @@ public class HobbyService {
 
     private final UserRepository userRepository;
     private final FavoritesRepository favoritesRepository;
+    private final PartyBoardRepository partyBoardRepository;
+    private final PartyBoardMapper partyBoardMapper;
 
-    public HobbyService(HobbyRepository hobbyRepository, HobbyMapper hobbyMapper, UserRepository userRepository, FavoritesRepository favoritesRepository) {
+    public HobbyService(HobbyRepository hobbyRepository,
+                        HobbyMapper hobbyMapper,
+                        UserRepository userRepository,
+                        FavoritesRepository favoritesRepository,
+                        PartyBoardRepository partyBoardRepository,
+                        PartyBoardMapper partyBoardMapper) {
         this.hobbyRepository = hobbyRepository;
         this.hobbyMapper = hobbyMapper;
         this.userRepository = userRepository;
         this.favoritesRepository = favoritesRepository;
+        this.partyBoardRepository=partyBoardRepository;
+        this.partyBoardMapper=partyBoardMapper;
     }
 
     //전체 hobby 불러오기
@@ -101,6 +114,15 @@ public class HobbyService {
         Favorites favorites=favoritesRepository.save(favoritesEntity);
 
         return favorites;
+    }
+
+    //취미 번호를 통해 해당하는 모임리스트 조회
+    public List<PartyBoardDTOForDetail> getPartyBoardByHobbyNumber(int hobbyNumber) {
+        Hobby hobby=hobbyRepository.findById(hobbyNumber).orElseThrow(() -> new IllegalArgumentException("해당 취미 번호가 존재하지 않습니다: " + hobbyNumber));;
+        List<PartyBoard> partyBoardList=partyBoardRepository.findByHobby(hobby);
+        List<PartyBoardDTOForDetail> partyBoardDTOList=partyBoardList.stream().map(partyBoardMapper::toPartyBoardDTOForDetail).toList();
+
+        return partyBoardDTOList;
     }
 
 }

--- a/src/main/java/com/senials/partyboard/repository/PartyBoardRepository.java
+++ b/src/main/java/com/senials/partyboard/repository/PartyBoardRepository.java
@@ -1,6 +1,7 @@
 package com.senials.partyboard.repository;
 
 import com.senials.hobbyboard.entity.Hobby;
+import com.senials.partyboard.dto.PartyBoardDTO;
 import com.senials.partyboard.entity.PartyBoard;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,5 +18,7 @@ public interface PartyBoardRepository extends JpaRepository<PartyBoard, Integer>
     PartyBoard findByPartyBoardNumber(int partyBoardNumber);
 
     Page<PartyBoard> findAllByHobbyIn(List<Hobby> hobby, Pageable pageable);
+
+    List<PartyBoard> findByHobby(Hobby hobby);
 
 }


### PR DESCRIPTION
## 이슈
- #31 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/156c4c38-3d57-4148-8ab6-41e2d9db845c)


## 📝작업 내용
- 맞춤형 취미 추천 관련 모임 조회 Rest api 기능 구현
  - repository PartyBoardSpecification findByHobby() 쿼리 메소드 추가
  - service HobbyService getPartyBoardByHobbyNumber() 메소드 추가, 취미 번호를 통해 해당하는 모임리스트 조회
  - controller HobbyController getPartyBoardByHobbyNumber() 메소드추가, 맞춤형 취미 추천 관련 모임 조회


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/f3191ef1-ba06-4f14-99cb-824c307d55fe)
![image](https://github.com/user-attachments/assets/ed084547-fbf0-4189-81c2-6774b9f37435)
![image](https://github.com/user-attachments/assets/67bd7d66-ba89-4ca6-bcb6-ec62c6ae4302)




## 🚨수정 필요 내용
- 
