### PR TITLE
[feature/backend-47/users/get-user-party-count] 사용자 별 모임 개수 조회 Rest api 기능 추가

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -46,3 +46,12 @@ Content-Type: application/json
   "userDetail": "새 사용자 상세 정보",
   "userProfileImg": "https://example.com/new-profile-image.jpg"
 }
+
+### 사용자가 참여한 모임 개수 출력
+GET http://localhost:8080/users/1/parties/count
+
+### 사용자가 만든 모임 개수 출력
+GET http://localhost:8080/users/1/made/count
+
+### 사용자가 좋아한 모임 개수 출력
+GET http://localhost:8080/users/1/like/count

--- a/src/main/java/com/senials/likes/controller/LikesController.java
+++ b/src/main/java/com/senials/likes/controller/LikesController.java
@@ -43,10 +43,19 @@ public class LikesController {
                 .body(new ResponseMessage(200, "사용자가 만든 모임 조회 성공", responseMap));
     }
 
-    //사용자가 좋아한 상태별 모임 목록
-/*    @GetMapping("/{userNumber}/likes/{partyBoardStatus}")
-    public ResponseEntity<List<PartyBoardDTOForCard>> getLikedPartyBoardsStatus(@PathVariable int userNumber) {
-        List<PartyBoardDTOForCard> likedBoards = likesService.getLikedPartyBoardsByUserNumber(userNumber);
-        return ResponseEntity.ok(likedBoards);
-    }*/
+    /*사용자 별 좋아요 한 모임 개수*/
+    @GetMapping("/{userNumber}/like/count")
+    public ResponseEntity<ResponseMessage> countUserLikeParties(@PathVariable int userNumber) {
+        long count = likesService.countLikesPartyBoardsByUserNumber(userNumber);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("likesPartyCount", count);
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "사용자가 좋아요한 개수 조회 성공", responseMap));
+    }
 }

--- a/src/main/java/com/senials/likes/repository/LikeRepository.java
+++ b/src/main/java/com/senials/likes/repository/LikeRepository.java
@@ -24,4 +24,7 @@ public interface LikeRepository extends JpaRepository<Likes, Integer> {
 
     // 페이지네이션 용
     Page<Likes> findAllByUser(User user, Pageable pageable);
+
+    /*사용자별 좋아요 한 모임 개수*/
+    long countByUser(User user);
 }

--- a/src/main/java/com/senials/likes/service/LikesService.java
+++ b/src/main/java/com/senials/likes/service/LikesService.java
@@ -67,6 +67,15 @@ public class LikesService {
                     firstImage
             );
         }).collect(Collectors.toList());
-
     }
+
+    /*모임 개수 api*/
+    /*사용자 별 좋아요 한 모임 개수*/
+    public long countLikesPartyBoardsByUserNumber(int userNumber) {
+        User user = userRepository.findById(userNumber)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        return likesRepository.countByUser(user);
+    }
+
 }

--- a/src/main/java/com/senials/partyboard/repository/PartyBoardRepository.java
+++ b/src/main/java/com/senials/partyboard/repository/PartyBoardRepository.java
@@ -22,4 +22,7 @@ public interface PartyBoardRepository extends JpaRepository<PartyBoard, Integer>
     /* 페이지네이션 용 */
     Page<PartyBoard> findByUser(User user, Pageable pageable);
 
+    /*사용자별 만든 모임의 수*/
+    long countByUser(User user);
+
 }

--- a/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
+++ b/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
@@ -11,4 +11,7 @@ import java.util.List;
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Integer> {
     List<PartyMember> findByUser_UserNumber(int userNumber); // 사용자별 참여 데이터 조회
     Page<PartyMember> findByUser_UserNumber(int userNumber, Pageable pageable);
+
+    /*사용자별 참여한 모임 개수*/
+    long countByUser_UserNumber(int userNumber);
 }

--- a/src/main/java/com/senials/user/controller/UserController.java
+++ b/src/main/java/com/senials/user/controller/UserController.java
@@ -171,4 +171,37 @@ public class UserController {
                 .body(new ResponseMessage(200, "사용자가 만든 모임 조회 성공", responseMap));
     }
 
+
+    /*모임 개수 api*/
+
+    /*사용자 별 참여한 모임 개수*/
+    @GetMapping("/{userNumber}/parties/count")
+    public ResponseEntity<ResponseMessage> countUserJoinedParties(@PathVariable int userNumber) {
+        long count = userService.countPartiesPartyBoardsByUserNumber(userNumber);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("partiesPartyCount", count);
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "사용자가 참여한 모임 개수 조회 성공", responseMap));
+    }
+    /*사용자 별 만든 모임 개수*/
+    @GetMapping("/{userNumber}/made/count")
+    public ResponseEntity<ResponseMessage> countUserMadeParties(@PathVariable int userNumber) {
+        long count = userService.countMadePartyBoardsByUserNumber(userNumber);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("madePartyCount", count);
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(new ResponseMessage(200, "사용자가 만든 모임 개수 조회 성공", responseMap));
+    }
 }

--- a/src/main/java/com/senials/user/service/UserService.java
+++ b/src/main/java/com/senials/user/service/UserService.java
@@ -161,5 +161,19 @@ public class UserService {
         }).collect(Collectors.toList());
     }
 
+    /*모임 개수 api*/
+    /*사용자 별 참여한 모임 개수*/
+    public long countPartiesPartyBoardsByUserNumber(int userNumber) {
+        return partyMemberRepository.countByUser_UserNumber(userNumber);
+    }
+
+    /*사용자 별 만든 모임 개수*/
+    public long countMadePartyBoardsByUserNumber(int userNumber) {
+        User user = userRepository.findById(userNumber)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        return partyBoardRepository.countByUser(user);
+    }
+
 
 }


### PR DESCRIPTION
## 이슈
- Resolve #47


## 📁 작업 파일
![스크린샷(8497)](https://github.com/user-attachments/assets/77e3f7e3-f3a1-4fcc-b064-dcfb0759f81f)


## 📝작업 내용
- 사용자 별 모임 개수 조회 Rest api 설계
  - 좋아요 한 모임 개수
  - 참여한 모임 개수
  - 만든 모임 개수


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![스크린샷(8496)](https://github.com/user-attachments/assets/266647c0-ed09-4644-a079-05f5950ff921)
![스크린샷(8501)](https://github.com/user-attachments/assets/39181aae-0a5e-4eb7-895e-38bb15be9d91)
![스크린샷(8499)](https://github.com/user-attachments/assets/bfef05bf-ad59-460b-aa1a-29c8f629d3b1)
![스크린샷(8500)](https://github.com/user-attachments/assets/9bd0111a-bc92-4d33-93c9-daa0005ce9bf)


## 🚨수정 필요 내용
- 
