### PR TITLE
[bugfix/backend-98/duplicated-method] PartyMemberRepository 메소드 중복

### DIFF
--- a/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
+++ b/src/main/java/com/senials/partymember/repository/PartyMemberRepository.java
@@ -5,15 +5,10 @@ import com.senials.partymember.entity.PartyMember;
 import org.springframework.data.domain.Page;
 import com.senials.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Integer> {
-
-    List<PartyMember> findByUser_UserNumber(int userNumber); // 사용자별 참여 데이터 조회
-    Page<PartyMember> findByUser_UserNumber(int userNumber, Pageable pageable);
 
     /*사용자별 참여한 모임 개수*/
     long countByUser_UserNumber(int userNumber);
@@ -24,4 +19,5 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember, Intege
     List<PartyMember> findAllByPartyBoard(PartyBoard partyBoard);
 
     PartyMember findByPartyBoardAndUser(PartyBoard partyBoard, User user);
+
 }


### PR DESCRIPTION
## 이슈
- Resolve #98 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/e254b112-1c60-4a96-84fd-8b0fa5b51c70)


## 📝작업 내용
- 중복된 PartyMemberRepository 메소드 제거


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
정상 실행 확인
![image](https://github.com/user-attachments/assets/3ff29778-8c32-477f-b6af-e901ffb0b8e7)

