### PR TITLE
[feature/backend-148/meetmembers/rest-api] 일정 멤버 목록 REST API 개선

### DIFF
--- a/http/meet.http
+++ b/http/meet.http
@@ -42,3 +42,7 @@ DELETE http://localhost:8080/partyboards/2/meets/7
 
 ### 모임 일정 참여멤버 조회
 GET http://localhost:8080/partyboards/1/meets/1/meetmembers
+
+
+###
+GET http://localhost:8080/meets/3

--- a/http/meetmember.http
+++ b/http/meetmember.http
@@ -8,3 +8,7 @@ POST http://localhost:8080/meets/500/meetmembers
 
 ### 일정 참여 취소
 DELETE http://localhost:8080/meets/1/meetmembers
+
+
+###
+GET http://localhost:8080/meets/3/meetmembers

--- a/src/main/java/com/senials/common/mapper/MeetMapper.java
+++ b/src/main/java/com/senials/common/mapper/MeetMapper.java
@@ -1,6 +1,7 @@
 package com.senials.common.mapper;
 
 import com.senials.meet.dto.MeetDTO;
+import com.senials.meet.dto.MeetDTOForMember;
 import com.senials.meet.entity.Meet;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
@@ -10,6 +11,9 @@ public interface MeetMapper {
 
     // Meet -> MeetDTO
     MeetDTO toMeetDTO(Meet meet);
+
+    /* Meet -> MeetDTOForMember */
+    MeetDTOForMember toMeetDTOForMember(Meet meet);
 
     /* MeetDTO -> Meet */
     Meet toMeet(MeetDTO meetDTO);

--- a/src/main/java/com/senials/meet/controller/MeetController.java
+++ b/src/main/java/com/senials/meet/controller/MeetController.java
@@ -1,7 +1,9 @@
 package com.senials.meet.controller;
 
 import com.senials.common.ResponseMessage;
+import com.senials.config.HttpHeadersFactory;
 import com.senials.meet.dto.MeetDTO;
+import com.senials.meet.dto.MeetDTOForMember;
 import com.senials.meet.repository.MeetRepository;
 import com.senials.meet.service.MeetService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,15 +20,30 @@ import java.util.Map;
 @RestController
 public class MeetController {
 
+    private final HttpHeadersFactory httpHeadersFactory;
     private Integer loggedInUserNumber = 3;
     private final MeetService meetService;
     private final MeetRepository meetRepository;
 
 
     @Autowired
-    public MeetController(MeetService meetService, MeetRepository meetRepository) {
+    public MeetController(MeetService meetService, MeetRepository meetRepository, HttpHeadersFactory httpHeadersFactory) {
         this.meetService = meetService;
         this.meetRepository = meetRepository;
+        this.httpHeadersFactory = httpHeadersFactory;
+    }
+
+    /* 모임 일정 조회 */
+    @GetMapping("/meets/{meetNumber}")
+    public ResponseEntity<ResponseMessage> getMeetByMeetNumber(
+            @PathVariable Integer meetNumber
+    ) {
+        MeetDTOForMember meetDTO = meetService.getMeetByNumber(meetNumber);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("meet" , meetDTO);
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "일정 조회 성공", responseMap));
     }
 
 

--- a/src/main/java/com/senials/meet/dto/MeetDTOForMember.java
+++ b/src/main/java/com/senials/meet/dto/MeetDTOForMember.java
@@ -1,0 +1,48 @@
+package com.senials.meet.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class MeetDTOForMember {
+
+    private int meetNumber;
+
+    private int partyBoardNumber;
+
+    private LocalDate meetStartDate;
+
+    private LocalDate meetEndDate;
+
+    private LocalTime meetStartTime;
+
+    private LocalTime meetFinishTime;
+
+    private int meetEntryFee;
+
+    private String meetLocation;
+
+    private int meetMaxMember;
+
+
+    /* AllArgsConstructor */
+    public MeetDTOForMember(int meetNumber, int partyBoardNumber, LocalDate meetStartDate, LocalDate meetEndDate, LocalTime meetStartTime, LocalTime meetFinishTime, int meetEntryFee, String meetLocation, int meetMaxMember) {
+        this.meetNumber = meetNumber;
+        this.partyBoardNumber = partyBoardNumber;
+        this.meetStartDate = meetStartDate;
+        this.meetEndDate = meetEndDate;
+        this.meetStartTime = meetStartTime;
+        this.meetFinishTime = meetFinishTime;
+        this.meetEntryFee = meetEntryFee;
+        this.meetLocation = meetLocation;
+        this.meetMaxMember = meetMaxMember;
+    }
+}

--- a/src/main/java/com/senials/meet/service/MeetService.java
+++ b/src/main/java/com/senials/meet/service/MeetService.java
@@ -3,6 +3,7 @@ package com.senials.meet.service;
 import com.senials.common.mapper.MeetMapper;
 import com.senials.common.mapper.MeetMapperImpl;
 import com.senials.meet.dto.MeetDTO;
+import com.senials.meet.dto.MeetDTOForMember;
 import com.senials.meet.entity.Meet;
 import com.senials.meet.repository.MeetRepository;
 import com.senials.meetmember.repository.MeetMemberRepository;
@@ -48,6 +49,13 @@ public class MeetService {
         this.partyMemberRepository = partyMemberRepository;
         this.userRepository = userRepository;
         this.meetMemberRepository = meetMemberRepository;
+    }
+
+    public MeetDTOForMember getMeetByNumber(int meetNumber) {
+        Meet meet = meetRepository.findById(meetNumber)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 요청"));
+
+        return meetMapper.toMeetDTOForMember(meet);
     }
 
     /* 모임 내 일정 개수 확인 */

--- a/src/main/java/com/senials/meetmember/controller/MeetMemberController.java
+++ b/src/main/java/com/senials/meetmember/controller/MeetMemberController.java
@@ -42,11 +42,14 @@ public class MeetMemberController {
     }
 
     /* 모임 일정 참여멤버 조회 */
-    @GetMapping("/partyboards/{partyBoardNumber}/meets/{meetNumber}/meetmembers")
+    @GetMapping("/meets/{meetNumber}/meetmembers")
     public ResponseEntity<ResponseMessage> getMeetMembersByMeetNumber(
             @PathVariable Integer meetNumber
+            ,@RequestParam(required = false, defaultValue = "100") Integer pageSize
+            ,@RequestParam(required = false, defaultValue = "0") Integer pageNumber
     ) {
-        List<UserDTOForPublic> meetMemberList = meetMemberService.getMeetMembersByMeetNumber(meetNumber);
+
+        List<UserDTOForPublic> meetMemberList = meetMemberService.getMeetMembersByMeetNumber(loggedInUserNumber, meetNumber, pageNumber, pageSize);
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("meetMembers", meetMemberList);

--- a/src/main/java/com/senials/meetmember/repository/MeetMemberRepository.java
+++ b/src/main/java/com/senials/meetmember/repository/MeetMemberRepository.java
@@ -3,6 +3,8 @@ package com.senials.meetmember.repository;
 import com.senials.meet.entity.Meet;
 import com.senials.meetmember.entity.MeetMember;
 import com.senials.partymember.entity.PartyMember;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,6 +13,7 @@ public interface MeetMemberRepository extends JpaRepository<MeetMember, Integer>
 
     /* 모임 일정 참여멤버 조회 */
     List<MeetMember> findAllByMeet(Meet meet);
+    Page<MeetMember> findAllByMeet(Meet meet, Pageable pageable);
 
     /* 모임 멤버 가입상태 확인 */
     MeetMember findByMeetAndPartyMember(Meet meet, PartyMember partyMember);


### PR DESCRIPTION
## 이슈
- Resolve #148 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/86fb753c-b3b8-45d9-9ee0-f54eee697dff)

## 📝작업 내용
- 일정 참여 멤버 목록 REST API 개선
- 일정 단일 조회 구현
- 일정 미참여 멤버 접근 제한

## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/85aaa9ea-1040-428e-80b1-0d4f2f386c7c)
![image](https://github.com/user-attachments/assets/d89b88f5-b78b-456e-851c-44a0216d837a)


## 🚨수정 필요 내용
- 나중에 모임 정보도 받아와서 좀 다듬어야 할듯