### PR TITLE
[bugfix/backend-147/ Missing_database_value] 취미 엔티티 항목 누락 수정

### DIFF
--- a/http/hobbyTest.http
+++ b/http/hobbyTest.http
@@ -1,7 +1,7 @@
 ###취미 게시판 전체 보기
 GET http://localhost:8081/hobby-board
 
-###
+###취미 이미지 조회
 GET http://localhost:8081/img/hobbyboard/1
 
 ###취미 게시판 인기 취미 조회
@@ -26,7 +26,8 @@ Content-Type: application/json;charset=UTF-8
   "hobbyReviewHealthStatus": 1,
   "hobbyReviewTendency": 1,
   "hobbyReviewLevel": 3,
-  "hobbyReviewWriteDate": "2024-12-02"
+  "hobbyReviewBudget": 2,
+  "hobbyReviewWriteDate": "2024-12-13T18:45:06"
 }
 
 ###취미 게시판 후기 삭제
@@ -42,7 +43,7 @@ Content-Type: application/json;charset=UTF-8
   "hobbyReviewHealthStatus": 3,
   "hobbyReviewTendency": 2,
   "hobbyReviewLevel": 1,
-  "hobbyReviewWriteDate": "2024-12-02"
+  "hobbyReviewWriteDate": "2024-12-13T18:45:06"
 }
 
 ###맞춤형 취미 추천 결과 조회

--- a/src/main/java/com/senials/hobbyreview/dto/HobbyReviewDTO.java
+++ b/src/main/java/com/senials/hobbyreview/dto/HobbyReviewDTO.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @NoArgsConstructor
@@ -22,9 +23,20 @@ public class HobbyReviewDTO {
     private int hobbyReviewHealthStatus; // 건강 상태 (예: true = 예, false = 아니요)
     private int hobbyReviewTendency; // 성향 (예: true = 외향적, false = 내향적)
     private int hobbyReviewLevel; // 취미 난이도 (1-쉬움, 2-약간 쉬움, 3-평범, 4-약간 어려움, 5-어려움)
-    private Date hobbyReviewWriteDate; // 후기 작성 날짜
+    private int hobbyReviewBudget;
+    private LocalDateTime hobbyReviewWriteDate; // 후기 작성 날짜
 
-    public HobbyReviewDTO(int hobbyReviewNumber, int userNumber, String userName, int hobbyNumber, int hobbyReviewRate, String hobbyReviewDetail, int hobbyReviewHealthStatus, int hobbyReviewTendency, int hobbyReviewLevel, Date hobbyReviewWriteDate) {
+    public HobbyReviewDTO(int hobbyReviewNumber,
+                          int userNumber,
+                          String userName,
+                          int hobbyNumber,
+                          int hobbyReviewRate,
+                          String hobbyReviewDetail,
+                          int hobbyReviewHealthStatus,
+                          int hobbyReviewTendency,
+                          int hobbyReviewLevel,
+                          int hobbyReviewBudget,
+                          LocalDateTime hobbyReviewWriteDate) {
         this.hobbyReviewNumber = hobbyReviewNumber;
         this.userNumber = userNumber;
         this.userName = userName;
@@ -34,6 +46,7 @@ public class HobbyReviewDTO {
         this.hobbyReviewHealthStatus = hobbyReviewHealthStatus;
         this.hobbyReviewTendency = hobbyReviewTendency;
         this.hobbyReviewLevel = hobbyReviewLevel;
+        this.hobbyReviewBudget=hobbyReviewBudget;
         this.hobbyReviewWriteDate = hobbyReviewWriteDate;
     }
 }

--- a/src/main/java/com/senials/hobbyreview/entity/HobbyReview.java
+++ b/src/main/java/com/senials/hobbyreview/entity/HobbyReview.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @NoArgsConstructor
 @Getter
@@ -41,15 +42,25 @@ public class HobbyReview {
     private int hobbyReviewTendency; // 성향 (1=외향적, 0=내향적)
 
     @Column(name = "hobby_review_level", nullable = false)
-    private int hobbyReviewLevel; // 난이도 (1-쉬움, 2-약간쉬움, 3-평범, 4-약간어려움, 5-어려움)
+    private int hobbyReviewLevel; // 난이도 (0-쉬움, 1-약간쉬움, 2-평범, 3-약간어려움, 4-어려움)
+
+    @Column(name = "hobby_review_budget", nullable = false)
+    private int hobbyReviewBudget; // 비용 (0- 0~100,000, 1- 100,000~400,000-, 2- 400,000~1,000,000, 3- 1,000,000~)
 
     @Column(name = "hobby_review_write_date", nullable = false)
-    private LocalDate hobbyReviewWriteDate; // 리뷰 작성 날짜
+    private LocalDateTime hobbyReviewWriteDate; // 리뷰 작성 날짜
 
 
     /* AllArgsConstructor */
     @Builder
-    public HobbyReview(int hobbyReviewNumber, User user, Hobby hobby, int hobbyReviewRate, String hobbyReviewDetail, int hobbyReviewHealthStatus, int hobbyReviewTendency, int hobbyReviewLevel, LocalDate hobbyReviewWriteDate) {
+    public HobbyReview(int hobbyReviewNumber,
+                       User user,
+                       Hobby hobby,
+                       int hobbyReviewRate,
+                       String hobbyReviewDetail,
+                       int hobbyReviewHealthStatus,
+                       int hobbyReviewTendency, int hobbyReviewLevel,
+                       LocalDateTime hobbyReviewWriteDate) {
         this.hobbyReviewNumber = hobbyReviewNumber;
         this.user = user;
         this.hobby = hobby;
@@ -87,6 +98,9 @@ public class HobbyReview {
 
     public void updateHobbyReviewLevel(int hobbyReviewLevel) {
         this.hobbyReviewLevel = hobbyReviewLevel;
+    }
+    public void updateHobbyReviewBudget(int hobbyReviewBudget) {
+        this.hobbyReviewBudget = hobbyReviewBudget;
     }
 
 }

--- a/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
+++ b/src/main/java/com/senials/hobbyreview/service/HobbyReviewService.java
@@ -108,6 +108,7 @@ public class HobbyReviewService {
         hobbyReview.updateHobbyReviewHealthStatus(hobbyReviewDTO.getHobbyReviewHealthStatus());
         hobbyReview.updateHobbyReviewTendency(hobbyReviewDTO.getHobbyReviewTendency());
         hobbyReview.updateHobbyReviewLevel(hobbyReviewDTO.getHobbyReviewLevel());
+        hobbyReview.updateHobbyReviewBudget(hobbyReviewDTO.getHobbyReviewBudget());
 
         return hobbyReviewRepository.save(hobbyReview);
     }


### PR DESCRIPTION
## 이슈
- #147 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/849db898-fa94-4e21-81f7-f7e891ace95a)


## 📝작업 내용
- 취미 엔티티 항목 누락 수정
  - 취미 리뷰 엔티티 사용가능 금액 항목 누락 추가
  - 취미 리뷰 dto 사용가능 금액 항목 누락 추가
  - 취미 리뷰 서비스 메소드 사용가능 금액 조회 기능 추가
  - 맞춤형 취미 추천 로직 개선


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/dcc0259f-fff4-47e6-b2e9-b560f2c1709f)
![image](https://github.com/user-attachments/assets/e881481e-3a34-4dec-baaf-08d6dd4650ee)
![image](https://github.com/user-attachments/assets/a94b3f25-5db9-4edc-b4b2-2a31c7d4fc1d)
![image](https://github.com/user-attachments/assets/b51b72d1-9b62-4764-af8b-e3c4a74aa043)


## 🚨수정 필요 내용
- 
