### PR TITLE
[feature/backend-159/suggestion/suggestion-api] 건의 페이지 건의 사항 Rest api 구현

### DIFF
--- a/http/suggestion.http
+++ b/http/suggestion.http
@@ -1,0 +1,13 @@
+###건의 생성
+POST http://localhost:8081/suggestion
+Content-Type: application/json;charset=UTF-8
+
+{
+  "suggestionTitle":"건의 작성 테스트 제목",
+  "suggestionType":0,
+  "suggestionDetail":"건의 작성 테스트 내용" ,
+  "suggestionDate": "2024-12-13T18:45:06"
+}
+
+###건의 리스트 전체 조회
+GET http://localhost:8081/suggestion

--- a/http/suggestion.http
+++ b/http/suggestion.http
@@ -1,13 +1,11 @@
 ###건의 생성
 POST http://localhost:8081/suggestion
 Content-Type: application/json;charset=UTF-8
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzaWdudXBEYXRlIjoiMjAyNC0xMi0xNSIsInN1YiI6Iuq5gOyDgeydtSIsInVzZXJTdGF0dXMiOjAsImdlbmRlciI6MCwidXNlckRldGFpbCI6bnVsbCwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImJpcnRoIjoiMjAyNC0xMi0wNCIsIm5pY2tuYW1lIjoiR1RVIiwidXNlclV1aWQiOiI5MTY1NWVmYi01ZjU3LTQ2YmYtODkyNi0xMWY5MjdhM2U3NTAiLCJyZXBvcnRDb3VudCI6MCwicHJvZmlsZUltZyI6IjEucG5nIiwiZXhwIjoxNzM0MzU4OTYzLCJ1c2VyTnVtYmVyIjoxLCJpYXQiOjE3MzQyNzI1NjMsImVtYWlsIjoic2FuZ2lrOTk5OUBuYXZlci5jb20ifQ.v4CQ5qJOTNfgn0BnL49n0oWLYiql53TxOnQ-BdmwkNY
 
 {
   "suggestionTitle":"건의 작성 테스트 제목",
   "suggestionType":0,
-  "suggestionDetail":"건의 작성 테스트 내용" ,
-  "suggestionDate": "2024-12-13T18:45:06"
+  "suggestionDetail":"건의 작성 테스트 내용"
 }
 
 ###건의 리스트 전체 조회

--- a/http/suggestion.http
+++ b/http/suggestion.http
@@ -1,6 +1,7 @@
 ###건의 생성
 POST http://localhost:8081/suggestion
 Content-Type: application/json;charset=UTF-8
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzaWdudXBEYXRlIjoiMjAyNC0xMi0xNSIsInN1YiI6Iuq5gOyDgeydtSIsInVzZXJTdGF0dXMiOjAsImdlbmRlciI6MCwidXNlckRldGFpbCI6bnVsbCwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImJpcnRoIjoiMjAyNC0xMi0wNCIsIm5pY2tuYW1lIjoiR1RVIiwidXNlclV1aWQiOiI5MTY1NWVmYi01ZjU3LTQ2YmYtODkyNi0xMWY5MjdhM2U3NTAiLCJyZXBvcnRDb3VudCI6MCwicHJvZmlsZUltZyI6IjEucG5nIiwiZXhwIjoxNzM0MzU4OTYzLCJ1c2VyTnVtYmVyIjoxLCJpYXQiOjE3MzQyNzI1NjMsImVtYWlsIjoic2FuZ2lrOTk5OUBuYXZlci5jb20ifQ.v4CQ5qJOTNfgn0BnL49n0oWLYiql53TxOnQ-BdmwkNY
 
 {
   "suggestionTitle":"건의 작성 테스트 제목",
@@ -11,3 +12,6 @@ Content-Type: application/json;charset=UTF-8
 
 ###건의 리스트 전체 조회
 GET http://localhost:8081/suggestion
+
+###특정 건의 조회
+GET http://localhost:8081/suggestion/1

--- a/src/main/java/com/senials/common/mapper/SuggestionMapper.java
+++ b/src/main/java/com/senials/common/mapper/SuggestionMapper.java
@@ -1,0 +1,12 @@
+package com.senials.common.mapper;
+
+import com.senials.suggestion.dto.SuggestionDTO;
+import com.senials.suggestion.entity.Suggestion;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface SuggestionMapper {
+    SuggestionDTO toSuggestionDTO(Suggestion suggestion);
+    Suggestion toSuggestionEntity(SuggestionDTO suggestionDTO);
+}

--- a/src/main/java/com/senials/report/entity/Report.java
+++ b/src/main/java/com/senials/report/entity/Report.java
@@ -53,8 +53,8 @@ public class Report {
     @Column(name = "report_detail", nullable = false, length = 5000)
     private String reportDetail;
 
-    @Column(name = "report_ctgr", nullable = false)
-    private int reportCtgr;
+    @Column(name = "report_target_type", nullable = false)
+    private int reportTargetType;
 
     @Column(name = "report_date", nullable = false)
     private LocalDateTime reportDate;

--- a/src/main/java/com/senials/suggestion/Controller/SuggestionController.java
+++ b/src/main/java/com/senials/suggestion/Controller/SuggestionController.java
@@ -1,0 +1,76 @@
+package com.senials.suggestion.Controller;
+
+
+import com.senials.common.ResponseMessage;
+import com.senials.config.HttpHeadersFactory;
+import com.senials.suggestion.dto.SuggestionDTO;
+import com.senials.suggestion.entity.Suggestion;
+import com.senials.suggestion.service.SuggestionService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+public class SuggestionController {
+
+    private final SuggestionService suggestionService;
+
+    private final HttpHeadersFactory httpHeadersFactory;
+
+    public SuggestionController(SuggestionService suggestionService,
+                                HttpHeadersFactory httpHeadersFactory) {
+        this.suggestionService = suggestionService;
+        this.httpHeadersFactory=httpHeadersFactory;
+    }
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+    // JWT에서 userNumber를 추출하는 메서드
+    private int extractUserNumberFromToken(String token) {
+        // JWT 디코딩 로직 (예: jjwt 라이브러리 사용)
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey) // 비밀 키 설정
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.get("userNumber", Integer.class);
+    }
+
+    //건의 생성
+    @PostMapping("/suggestion")
+    public ResponseEntity<ResponseMessage> createSuggestion(
+            @RequestBody SuggestionDTO suggestionDTO,
+            @RequestHeader("Authorization") String token){
+
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+
+        int userNumber = extractUserNumberFromToken(token); // 토큰에서 userNumber 추출
+        suggestionDTO.setUserNumber(userNumber);
+
+        Suggestion suggestion=suggestionService.saveSuggestion(suggestionDTO);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("suggestion", suggestion);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "생성 성공", responseMap));
+    }
+
+    //건의 리스트 조회
+    @GetMapping("/suggestion")
+    public ResponseEntity<ResponseMessage> getSuggestion(){
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+
+        List<SuggestionDTO> suggestionDTOList =suggestionService.getSuggestionList();
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("suggestionDTOList", suggestionDTOList);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "생성 성공", responseMap));
+    }
+}

--- a/src/main/java/com/senials/suggestion/Controller/SuggestionController.java
+++ b/src/main/java/com/senials/suggestion/Controller/SuggestionController.java
@@ -73,4 +73,17 @@ public class SuggestionController {
 
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "생성 성공", responseMap));
     }
+
+    //특정 건의 조회
+    @GetMapping("/suggestion/{suggestionNumber")
+    public ResponseEntity<ResponseMessage> getSuggestionById(@PathVariable("suggestionNumber") int suggestionNumber){
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+
+        SuggestionDTO suggestionDTO=suggestionService.getSuggestionById(suggestionNumber);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("suggestionDTO", suggestionDTO);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "생성 성공", responseMap));
+    }
 }

--- a/src/main/java/com/senials/suggestion/controller/SuggestionController.java
+++ b/src/main/java/com/senials/suggestion/controller/SuggestionController.java
@@ -83,6 +83,15 @@ public class SuggestionController {
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("suggestionDTO", suggestionDTO);
 
-        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "생성 성공", responseMap));
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));
+    }
+
+    @DeleteMapping("/suggestion/{suggestionNumber}")
+    public ResponseEntity<ResponseMessage> deleteSuggestionById(@PathVariable("suggestionNumber") int suggestionNumber) {
+        HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
+
+        suggestionService.deleteSuggestionById(suggestionNumber);
+
+        return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "삭제 성공",null));
     }
 }

--- a/src/main/java/com/senials/suggestion/controller/SuggestionController.java
+++ b/src/main/java/com/senials/suggestion/controller/SuggestionController.java
@@ -1,4 +1,4 @@
-package com.senials.suggestion.Controller;
+package com.senials.suggestion.controller;
 
 
 import com.senials.common.ResponseMessage;
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
+@RequestMapping
 public class SuggestionController {
 
     private final SuggestionService suggestionService;
@@ -75,7 +76,7 @@ public class SuggestionController {
     }
 
     //특정 건의 조회
-    @GetMapping("/suggestion/{suggestionNumber")
+    @GetMapping("/suggestion/{suggestionNumber}")
     public ResponseEntity<ResponseMessage> getSuggestionById(@PathVariable("suggestionNumber") int suggestionNumber){
         HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
 

--- a/src/main/java/com/senials/suggestion/controller/SuggestionController.java
+++ b/src/main/java/com/senials/suggestion/controller/SuggestionController.java
@@ -86,6 +86,7 @@ public class SuggestionController {
         return ResponseEntity.ok().headers(headers).body(new ResponseMessage(200, "조회 성공", responseMap));
     }
 
+    //특정 건의 삭제
     @DeleteMapping("/suggestion/{suggestionNumber}")
     public ResponseEntity<ResponseMessage> deleteSuggestionById(@PathVariable("suggestionNumber") int suggestionNumber) {
         HttpHeaders headers = httpHeadersFactory.createJsonHeaders();

--- a/src/main/java/com/senials/suggestion/controller/SuggestionController.java
+++ b/src/main/java/com/senials/suggestion/controller/SuggestionController.java
@@ -52,9 +52,7 @@ public class SuggestionController {
         HttpHeaders headers = httpHeadersFactory.createJsonHeaders();
 
         int userNumber = extractUserNumberFromToken(token); // 토큰에서 userNumber 추출
-        suggestionDTO.setUserNumber(userNumber);
-
-        Suggestion suggestion=suggestionService.saveSuggestion(suggestionDTO);
+        Suggestion suggestion=suggestionService.saveSuggestion(suggestionDTO, userNumber);
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("suggestion", suggestion);

--- a/src/main/java/com/senials/suggestion/dto/SuggestionDTO.java
+++ b/src/main/java/com/senials/suggestion/dto/SuggestionDTO.java
@@ -1,0 +1,38 @@
+package com.senials.suggestion.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class SuggestionDTO {
+    private int suggestionNumber;
+    private int userNumber; //건의 추가 유저
+    private String userName;
+    private String suggestionTitle; // 건의 제목
+    private int suggestionType;     //0- 취미 추가, 1- 버그 제보
+    private String suggestionDetail; //건의 내용
+    private LocalDateTime suggestionDate;
+
+    public SuggestionDTO(int suggestionNumber,
+                         int userNumber,
+                         String userName,
+                         String suggestionTitle,
+                         int suggestionType,
+                         String suggestionDetail,
+                         LocalDateTime suggestionDate) {
+        this.suggestionNumber = suggestionNumber;
+        this.userNumber = userNumber;
+        this.userName=userName;
+        this.suggestionTitle = suggestionTitle;
+        this.suggestionType = suggestionType;
+        this.suggestionDetail = suggestionDetail;
+        this.suggestionDate = suggestionDate;
+    }
+}

--- a/src/main/java/com/senials/suggestion/entity/Suggestion.java
+++ b/src/main/java/com/senials/suggestion/entity/Suggestion.java
@@ -1,6 +1,7 @@
 package com.senials.suggestion.entity;
 
 import com.senials.user.entity.User;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -36,6 +37,15 @@ public class Suggestion {
     @Column(name = "suggestion_date", nullable = false)
     private LocalDateTime suggestionDate;
 
+    @Builder
+    public Suggestion(int suggestionNumber, User user, String suggestionTitle, int suggestionType, String suggestionDetail, LocalDateTime suggestionDate) {
+        this.suggestionNumber = suggestionNumber;
+        this.user = user;
+        this.suggestionTitle = suggestionTitle;
+        this.suggestionType = suggestionType;
+        this.suggestionDetail = suggestionDetail;
+        this.suggestionDate = suggestionDate;
+    }
 
     public void initializeUser(User user){
         this.user=user;

--- a/src/main/java/com/senials/suggestion/entity/Suggestion.java
+++ b/src/main/java/com/senials/suggestion/entity/Suggestion.java
@@ -37,4 +37,7 @@ public class Suggestion {
     private LocalDateTime suggestionDate;
 
 
+    public void initializeUser(User user){
+        this.user=user;
+    }
 }

--- a/src/main/java/com/senials/suggestion/repository/SuggestionRepository.java
+++ b/src/main/java/com/senials/suggestion/repository/SuggestionRepository.java
@@ -1,0 +1,8 @@
+package com.senials.suggestion.repository;
+
+import com.senials.suggestion.entity.Suggestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SuggestionRepository extends JpaRepository<Suggestion,Integer> {
+
+}

--- a/src/main/java/com/senials/suggestion/service/SuggestionService.java
+++ b/src/main/java/com/senials/suggestion/service/SuggestionService.java
@@ -8,6 +8,7 @@ import com.senials.user.entity.User;
 import com.senials.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,8 +28,9 @@ public class SuggestionService {
     }
 
     //건의사항을 생성
-    public Suggestion saveSuggestion(SuggestionDTO suggestionDTO){
-        User user=userRepository.findById(suggestionDTO.getUserNumber()).orElseThrow(()->new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: "));
+    public Suggestion saveSuggestion(SuggestionDTO suggestionDTO, int userNumber){
+        suggestionDTO.setSuggestionDate(LocalDateTime.now());
+        User user=userRepository.findById(userNumber).orElseThrow(()->new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: "));
         Suggestion suggestion=suggestionMapper.toSuggestionEntity(suggestionDTO);
         suggestion.initializeUser(user);
         Suggestion saveSuggestion=suggestionRepository.save(suggestion);

--- a/src/main/java/com/senials/suggestion/service/SuggestionService.java
+++ b/src/main/java/com/senials/suggestion/service/SuggestionService.java
@@ -44,4 +44,12 @@ public class SuggestionService {
                 .collect(Collectors.toList());
         return suggestionDTOList;
     }
+
+    //특정 건의 조회
+    public SuggestionDTO getSuggestionById(int suggestionNumber){
+        Suggestion suggestion=suggestionRepository.findById(suggestionNumber).orElseThrow(() -> new IllegalArgumentException("해당 건의는 존재하지 않습니다: " + suggestionNumber));
+        SuggestionDTO suggestionDTO=suggestionMapper.toSuggestionDTO(suggestion);
+
+        return suggestionDTO;
+    }
 }

--- a/src/main/java/com/senials/suggestion/service/SuggestionService.java
+++ b/src/main/java/com/senials/suggestion/service/SuggestionService.java
@@ -42,7 +42,12 @@ public class SuggestionService {
     public List<SuggestionDTO> getSuggestionList() {
         List<Suggestion> suggestionList = suggestionRepository.findAll();
         List<SuggestionDTO> suggestionDTOList = suggestionList.stream()
-                .map(suggestion ->suggestionMapper.toSuggestionDTO(suggestion))
+                .map(suggestion ->{
+                   SuggestionDTO suggestionDTO= suggestionMapper.toSuggestionDTO(suggestion);
+                   suggestionDTO.setUserNumber(suggestion.getUser().getUserNumber());
+                    suggestionDTO.setUserName(suggestion.getUser().getUserName());
+                   return suggestionDTO;
+                })
                 .collect(Collectors.toList());
         return suggestionDTOList;
     }
@@ -53,5 +58,10 @@ public class SuggestionService {
         SuggestionDTO suggestionDTO=suggestionMapper.toSuggestionDTO(suggestion);
 
         return suggestionDTO;
+    }
+
+    //특정 건의 삭제
+    public void deleteSuggestionById(int suggestionNumber){
+        suggestionRepository.deleteById(suggestionNumber);
     }
 }

--- a/src/main/java/com/senials/suggestion/service/SuggestionService.java
+++ b/src/main/java/com/senials/suggestion/service/SuggestionService.java
@@ -1,0 +1,47 @@
+package com.senials.suggestion.service;
+
+import com.senials.common.mapper.SuggestionMapper;
+import com.senials.suggestion.dto.SuggestionDTO;
+import com.senials.suggestion.entity.Suggestion;
+import com.senials.suggestion.repository.SuggestionRepository;
+import com.senials.user.entity.User;
+import com.senials.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class SuggestionService {
+
+    private final SuggestionRepository suggestionRepository;
+    private final SuggestionMapper suggestionMapper;
+    private final UserRepository userRepository;
+
+    public SuggestionService(SuggestionRepository suggestionRepository,
+                             SuggestionMapper suggestionMapper,
+                             UserRepository userRepository) {
+        this.suggestionRepository = suggestionRepository;
+        this.suggestionMapper = suggestionMapper;
+        this.userRepository = userRepository;
+    }
+
+    //건의사항을 생성
+    public Suggestion saveSuggestion(SuggestionDTO suggestionDTO){
+        User user=userRepository.findById(suggestionDTO.getUserNumber()).orElseThrow(()->new IllegalArgumentException("해당 유저 번호가 존재하지 않습니다: "));
+        Suggestion suggestion=suggestionMapper.toSuggestionEntity(suggestionDTO);
+        suggestion.initializeUser(user);
+        Suggestion saveSuggestion=suggestionRepository.save(suggestion);
+
+        return saveSuggestion;
+    }
+
+    //건의 전체 조회
+    public List<SuggestionDTO> getSuggestionList() {
+        List<Suggestion> suggestionList = suggestionRepository.findAll();
+        List<SuggestionDTO> suggestionDTOList = suggestionList.stream()
+                .map(suggestion ->suggestionMapper.toSuggestionDTO(suggestion))
+                .collect(Collectors.toList());
+        return suggestionDTOList;
+    }
+}


### PR DESCRIPTION
## 이슈
- #159 

## 📁 작업 파일
![image](https://github.com/user-attachments/assets/d4a5e1d1-fb27-4466-9449-a47c1bf71fc1)



## 📝작업 내용
- 건의 페이지 건의 사항 Rest api 구현
  - 건의 페이지 스프링 빈 구조 설정 및 생성
  - 건의 생성 rest api 구현
  - 건의 삭제 rest api 구현
  - 건의 전체 조회 rest api 구현
  - 특정 건희 조회 rest api 구현


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/93a66bc2-a4ee-4671-af9a-9ec676a4ad80)
![image](https://github.com/user-attachments/assets/66d36501-4b48-459c-82ca-760bffd3e6c0)
![image](https://github.com/user-attachments/assets/d44d0f84-f1b5-4158-918e-87fcef6e455d)


## 🚨수정 필요 내용
- 
